### PR TITLE
[Feat] 로그인 API 연동 구현 완료

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,10 +1,25 @@
 import axiosInstance from "./axiosInstance";
-import type { SignUpRequest, SignUpResponse } from "../types/user";
+import type {
+  LoginRequest,
+  LoginResponse,
+  SignUpRequest,
+  SignUpResponse,
+} from "../types/user";
 
 // 회원가입 API 요청 함수
-export const signUp = async (
-  request: SignUpRequest
-): Promise<SignUpResponse> => {
-  const response = await axiosInstance.post("/users/signup", request);
+export const signUp = async (data: SignUpRequest): Promise<SignUpResponse> => {
+  const response = await axiosInstance.post<SignUpResponse>(
+    "/users/signup",
+    data
+  );
+  return response.data;
+};
+
+// 로그인 API 요청 함수
+export const login = async (data: LoginRequest): Promise<LoginResponse> => {
+  const response = await axiosInstance.post<LoginResponse>(
+    "/users/login",
+    data
+  );
   return response.data;
 };

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { type InternalAxiosRequestConfig } from "axios";
 
 const axiosInstance = axios.create({
   // 백엔드 drf 서버 주소
@@ -7,5 +7,19 @@ const axiosInstance = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+// 요청 인터셉터
+axiosInstance.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const token = localStorage.getItem("access_token");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 export default axiosInstance;

--- a/src/components/forms/LoginForm.tsx
+++ b/src/components/forms/LoginForm.tsx
@@ -9,30 +9,46 @@ import {
 } from "@/components/ui/form";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import * as z from "zod";
-
-const loginFormSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
-  password: z.string().min(6, "Password must be at least 6 characters"),
-});
-
-type LoginFormValues = z.infer<typeof loginFormSchema>;
+import { useLoginMutation } from "@/hooks/useAuth";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { loginSchema, type LoginFormData } from "@/schemas/authSchema";
+import { AxiosError } from "axios";
 
 interface LoginFormProps {
   onSwitchToRegister: () => void;
 }
 
 const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
-  const form = useForm<LoginFormValues>({
-    resolver: zodResolver(loginFormSchema),
+  const { mutate: login, isPending, error } = useLoginMutation();
+
+  const form = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema),
     defaultValues: {
-      email: "",
+      username: "",
       password: "",
     },
+    mode: "onChange",
   });
 
-  const onSubmit = (values: LoginFormValues) => {
+  const onSubmit = (values: LoginFormData) => {
     console.log(values);
+    login(values, {
+      onSuccess: () => {
+        console.log("로그인 성공");
+        toast.success("로그인 성공");
+      },
+      onError: (error: any) => {
+        if (error.response?.data) {
+          const errorData = error.response.data;
+          if (errorData.detail) {
+            toast.error(errorData.detail);
+          }
+        } else {
+          toast.error("아이디 또는 비밀번호를 확인해주세요.");
+        }
+      },
+    });
   };
 
   return (
@@ -42,18 +58,21 @@ const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
       </h1>
 
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex flex-col gap-4"
+        >
           {/* Email Input */}
           <FormField
             control={form.control}
-            name="email"
+            name="username"
             render={({ field }) => (
               <FormItem>
                 <FormControl>
                   <Input
                     {...field}
-                    type="email"
-                    placeholder="Email or mobile phone number"
+                    type="text"
+                    placeholder="Username"
                     className="h-[50px] w-full bg-white/30 border border-[#5C5C5C]/30 shadow-[4px_4px_13px_rgba(242,113,144,0.15)] font-inter text-[14px] text-black placeholder:text-[#5C5C5C] px-[21px]"
                   />
                 </FormControl>
@@ -82,12 +101,32 @@ const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
           />
 
           {/* Login Button */}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            disabled={isPending || !form.formState.isValid}
             className="h-[48px] w-full bg-[#333333] hover:bg-[#444444] text-white font-inter font-bold text-[16px] leading-[20px] uppercase mt-4"
           >
-            Login
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                LOGINING...
+              </>
+            ) : (
+              "LOGIN"
+            )}
           </Button>
+
+          {/* Global Error Display */}
+          {error &&
+            (error as AxiosError<{ detail: string }>)?.response?.data
+              ?.detail && (
+              <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
+                {
+                  (error as AxiosError<{ detail: string }>)?.response?.data
+                    ?.detail
+                }
+              </div>
+            )}
 
           {/* Privacy Notice */}
           <p className="font-inter text-[14px] leading-[22px] text-[#5C5C5C] mt-2">

--- a/src/components/forms/SignupForm.tsx
+++ b/src/components/forms/SignupForm.tsx
@@ -17,7 +17,7 @@ import {
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSignUpMutation } from "@/hooks/useAuth";
-import { signUpSchema, type SignUpFormData } from "@/schemas/signUpSchema";
+import { signUpSchema, type SignUpFormData } from "@/schemas/authSchema";
 import { toast } from "sonner"; // 또는 사용하는 토스트 라이브러리
 import { Loader2 } from "lucide-react";
 import { AxiosError } from "axios";

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
-import { signUp } from "../api/auth";
-import type { SignUpRequest, SignUpResponse } from "../types/user";
+import { signUp, login } from "../api/auth";
+import type {
+  SignUpRequest,
+  SignUpResponse,
+  LoginRequest,
+  LoginResponse,
+} from "../types/user";
 import { AxiosError } from "axios";
 
 export const useSignUpMutation = () => {
@@ -15,6 +20,24 @@ export const useSignUpMutation = () => {
       // 실패 시
       console.log("회원가입 실패", error);
       alert("회원가입 중 오류가 발생했습니다.");
+    },
+  });
+};
+
+export const useLoginMutation = () => {
+  return useMutation<LoginResponse, AxiosError, LoginRequest>({
+    mutationFn: (userData: LoginRequest) => login(userData),
+    onSuccess: (data) => {
+      // 로그인 성공 시
+      console.log("로그인 성공", data);
+      alert(data.message);
+      // 로그인 성공 시 토큰 저장
+      localStorage.setItem("access_token", data.access_token);
+    },
+    onError: (error) => {
+      // 로그인 실패 시
+      console.log("로그인 실패", error);
+      alert("아이디 또는 비밀번호를 확인해주세요.");
     },
   });
 };

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -35,5 +35,11 @@ export const signUpSchema = z
     path: ["password2"], // 에러를 password2 필드에 표시
   });
 
+export const loginSchema = z.object({
+  username: z.string().min(1, "Username is required"),
+  password: z.string().min(1, "Password is required"),
+});
+
 // 타입 추출
 export type SignUpFormData = z.infer<typeof signUpSchema>;
+export type LoginFormData = z.infer<typeof loginSchema>;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,3 +10,14 @@ export interface SignUpResponse {
   status: number;
   message: string;
 }
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  status: number;
+  access_token: string;
+  message: string;
+}


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

--- [Feat] 로그인 API 연동 구현 완료

### ✨ Description

<!-- write down the work details and show the execution results. -->

--- 로그인 요청할 때 Axios 인터셉터를 통해 웹의 LocalStorage에 저장한 access_token을 자동으로 "Bearer <token>" 형식으로 보내게끔 설정함.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #22 