### PR TITLE
[feat] 장바구니 추가 다이얼로그 구현

### DIFF
--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -5,7 +5,6 @@ import type { ProductCardVariant } from "@/types/variants";
 interface ProductCardProps {
   variant?: ProductCardVariant;
   product: Product;
-  colorOptions?: number;
   quantity?: number;
   onQuantityChange?: (quantity: number) => void;
   onProductClick?: () => void;
@@ -14,7 +13,6 @@ interface ProductCardProps {
 const ProductCard = ({
   variant = "default",
   product,
-  colorOptions = 1,
   quantity = 1,
   onQuantityChange,
   onProductClick,
@@ -61,20 +59,6 @@ const ProductCard = ({
                   >
                     {product.name}
                   </span>
-                  {colorOptions > 1 && (
-                    <div className="flex items-center gap-0.5 ml-2">
-                      <div className="flex flex-col gap-2.5 w-[30px]">
-                        <div className="flex items-center justify-between gap-0.5">
-                          <div className="w-[11px] h-[11px] sm:w-[13px] sm:h-[13px] bg-[#D9D9D9] rounded-sm"></div>
-                          <span
-                            className={`text-[11px] sm:text-[13px] font-inter leading-tight ${getTextColor()}`}
-                          >
-                            +{colorOptions - 1}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  )}
                 </div>
 
                 {/* Price */}
@@ -120,20 +104,6 @@ const ProductCard = ({
                 >
                   {product.name}
                 </span>
-                {colorOptions > 1 && (
-                  <div className="flex items-center gap-0.5 ml-2">
-                    <div className="flex flex-col gap-2.5 w-[30px]">
-                      <div className="flex items-center justify-between gap-0.5">
-                        <div className="w-[11px] h-[11px] sm:w-[13px] sm:h-[13px] bg-[#D9D9D9] rounded-sm"></div>
-                        <span
-                          className={`text-[11px] sm:text-[13px] font-inter leading-tight ${getTextColor()}`}
-                        >
-                          +{colorOptions - 1}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                )}
               </div>
 
               {/* Price */}

--- a/src/components/dialogs/CartAddDialog.tsx
+++ b/src/components/dialogs/CartAddDialog.tsx
@@ -1,0 +1,104 @@
+import { useNavigate } from "react-router-dom";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import ProductCard from "@/components/common/ProductCard";
+import { productDummy } from "@/dummys/productDummy";
+import type { Product } from "@/types/product";
+
+interface CartAddDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  product: Product;
+}
+
+const CartAddDialog = ({ isOpen, onClose, product }: CartAddDialogProps) => {
+  const navigate = useNavigate();
+
+  const handleCartView = () => {
+    navigate("/cart");
+    onClose();
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onClose}>
+      <SheetContent
+        side="right"
+        className="!max-w-[544px] !w-[544px] !h-full !p-0 !m-0 !rounded-none !border-none !bg-white !shadow-none"
+      >
+        {/* Dialog Content */}
+        <div className="w-full h-full bg-white flex flex-col overflow-y-auto">
+          {/* Header */}
+          <div className="pt-[53px] px-[40px]">
+            <h2 className="text-black text-[15px] font-inter font-medium leading-[23px] tracking-[-0.017em]">
+              장바구니에 추가됨
+            </h2>
+          </div>
+
+          <div className="flex justify-start items-center">
+            {/* Added Product Image */}
+            <div className="pl-[44px] pr-[20px] mt-[76px]">
+              <div className="w-[134.4px] h-[201.6px] bg-gray-200 rounded-lg overflow-hidden">
+                <img
+                  src=""
+                  alt={product.name}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            </div>
+
+            {/* Product Info */}
+            <div className="h-full flex items-center pb-20">
+              <div className="flex flex-col gap-[7px]">
+                <p className="text-black text-[12px] font-inter font-medium leading-[18px] tracking-[-0.013em]">
+                  {product.name}
+                </p>
+                <p className="text-black text-[12px] font-inter font-medium leading-[18px] tracking-[-0.013em]">
+                  사이즈
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Cart View Button */}
+          <div className="px-[44px] mt-[39px]">
+            <button
+              onClick={handleCartView}
+              className="w-[134px] h-[27px] bg-white border-[0.5px] border-black flex items-center justify-center px-[32px] py-[5px] hover:bg-gray-50 transition-colors"
+            >
+              <span className="text-black text-[11px] font-inter font-medium leading-[17px] tracking-[-0.012em]">
+                장바구니 보기
+              </span>
+            </button>
+          </div>
+
+          {/* Other Products Section */}
+          <div className="px-[40px] mt-[80px]">
+            <h3 className="text-black text-[15px] font-inter font-medium leading-[23px] tracking-[-0.017em] mb-[45px]">
+              다른 사람들이 많이 본 상품
+            </h3>
+
+            {/* Products Grid */}
+            <div className="grid grid-cols-3 gap-[26px] w-[455.2px]">
+              {productDummy.slice(0, 6).map((item) => (
+                <div
+                  key={item.id}
+                  className="[&>div]:w-[134.4px] [&>div>div:first-child]:!w-[134.4px] [&>div>div:first-child]:!h-[201.6px]"
+                >
+                  <ProductCard
+                    variant="viewed"
+                    product={item}
+                    onProductClick={() => {
+                      navigate(`/product/${item.id}`);
+                      onClose();
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default CartAddDialog;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,55 +5,52 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
       },
     },
     defaultVariants: {
       variant: "default",
       size: "default",
     },
-  }
+  },
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
-  const Comp = asChild ? Slot : "button"
-
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
 }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,20 +2,24 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
 
 export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,24 +1,24 @@
-"use client"
-
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
-  return (
-    <LabelPrimitive.Root
-      data-slot="label"
-      className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
 
 export { Label }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  },
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/index.css
+++ b/src/index.css
@@ -122,3 +122,14 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes slide-in-right {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,11 +1,14 @@
 import { useParams } from "react-router-dom";
+import { useState } from "react";
 import ProductCard from "@/components/common/ProductCard";
 import { productDummy } from "@/dummys/productDummy";
 import { useNavigate } from "react-router-dom";
+import CartAddDialog from "@/components/dialogs/CartAddDialog";
 
 const Detail = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [isCartDialogOpen, setIsCartDialogOpen] = useState(false);
   const currentProduct = productDummy.find(
     (product) => product.id === Number(id) && !product.is_deleted
   );
@@ -73,7 +76,10 @@ const Detail = () => {
                   >
                     구매하기
                   </button>
-                  <button className="bg-white border border-black text-black text-[10px] font-inter py-[13px] px-[62px] w-[207px] h-[39px] flex items-center justify-center hover:bg-gray-50 transition-colors whitespace-nowrap">
+                  <button
+                    className="bg-white border border-black text-black text-[10px] font-inter py-[13px] px-[62px] w-[207px] h-[39px] flex items-center justify-center hover:bg-gray-50 transition-colors whitespace-nowrap"
+                    onClick={() => setIsCartDialogOpen(true)}
+                  >
                     장바구니 추가하기
                   </button>
                 </div>
@@ -191,14 +197,22 @@ const Detail = () => {
                   key={product.id}
                   variant="viewed"
                   product={product}
-                  colorOptions={3}
-                  onProductClick={() => {}}
+                  onProductClick={() => {
+                    navigate(`/product/${product.id}`);
+                  }}
                 />
               ))}
             </div>
           </div>
         </div>
       </div>
+
+      {/* Cart Add Dialog */}
+      <CartAddDialog
+        isOpen={isCartDialogOpen}
+        onClose={() => setIsCartDialogOpen(false)}
+        product={currentProduct}
+      />
     </div>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,7 +36,6 @@ const Home = () => {
                     key={product.id}
                     variant="default"
                     product={product}
-                    colorOptions={3}
                     onProductClick={() => handleProductClick(product.id)}
                   />
                 ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,7 +1360,7 @@ chownr@^3.0.0:
 
 class-variance-authority@^0.7.1:
   version "0.7.1"
-  resolved "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz#4008a798a0e4553a781a57ac5177c9fb5d043787"
   integrity sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==
   dependencies:
     clsx "^2.1.1"
@@ -2034,7 +2034,7 @@ lru-cache@^5.1.1:
 
 lucide-react@^0.525.0:
   version "0.525.0"
-  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.525.0.tgz#5f7bcecd65e4f9b2b5b6b5d295e3376df032d5e3"
   integrity sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==
 
 magic-string@^0.30.17:


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

--- 장바구니 추가 다이얼로그 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

- 기존에 쓰던 Shadcn의 Dialog 컴포넌트는 오른쪽에 붙어서 나오는 다이얼로그를 구현하기 어렵다고 판단.
- https://21st.dev/shadcn/sheet/with-form
- 21st에서 알맞는 컴포넌트를 찾고, 적용함.
- 다이얼로그의 추천 상품은 더미 데이터에서 6개 가져옴.
- 상품을 클릭하면 해당 상품의 상세 페이지로 이동함.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #37 