### PR TITLE
[Feat] 유저 인증 관련 API 연동

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -4,13 +4,30 @@ import type {
   LoginResponse,
   SignUpRequest,
   SignUpResponse,
+  LogoutResponse,
 } from "../types/user";
 
 // 회원가입 API 요청 함수
 export const signUp = async (data: SignUpRequest): Promise<SignUpResponse> => {
+  // FormData로 통일하여 전송
+  const formData = new FormData();
+  formData.append('username', data.username);
+  formData.append('email', data.email);
+  formData.append('password', data.password);
+  formData.append('password2', data.password2);
+  
+  if (data.profile_image) {
+    formData.append('profile_image', data.profile_image);
+  }
+  
   const response = await axiosInstance.post<SignUpResponse>(
     "api/v1/users/signup",
-    data
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
   );
   return response.data;
 };
@@ -20,6 +37,19 @@ export const login = async (data: LoginRequest): Promise<LoginResponse> => {
   const response = await axiosInstance.post<LoginResponse>(
     "api/v1/users/login",
     data
+  );
+  return response.data;
+};
+
+// 로그아웃 API 요청 함수
+export const logout = async (): Promise<LogoutResponse> => {
+  const refreshToken = localStorage.getItem("refresh_token");
+  
+  const response = await axiosInstance.post<LogoutResponse>(
+    "api/v1/users/logout",
+    {
+      refresh_token: refreshToken,
+    }
   );
   return response.data;
 };

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -6,14 +6,24 @@ const axiosInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
+  withCredentials: true, // 쿠키 전송을 위해 필요
 });
 
 // 요청 인터셉터
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    const token = localStorage.getItem("access_token");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    // 인증이 필요 없는 엔드포인트들
+    const publicEndpoints = ['api/v1/users/signup', 'api/v1/users/login'];
+    const isPublicEndpoint = publicEndpoints.some(endpoint => 
+      config.url?.includes(endpoint)
+    );
+    
+    // public 엔드포인트가 아닌 경우에만 Authorization 헤더 추가
+    if (!isPublicEndpoint) {
+      const token = localStorage.getItem("access_token");
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
     }
     return config;
   },

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,6 +4,7 @@ import LoginDialog from "@/components/dialogs/LoginDialog";
 import { useFilter } from "@/contexts/FilterContext";
 import type { HeaderVariant } from "@/types/variants";
 import { useCart } from "@/contexts/CartContext";
+import { useLogoutMutation } from "@/hooks/useAuth";
 
 interface HeaderProps {
   variant?: HeaderVariant;
@@ -29,8 +30,31 @@ const Header = ({
   const [scrollProgress, setScrollProgress] = useState(0);
   const [lastScrollY, setLastScrollY] = useState(0);
   const [isLogin, setIsLogin] = useState(false);
+
+  // 로그인 상태 체크
+  useEffect(() => {
+    const checkLoginStatus = () => {
+      const token = localStorage.getItem("access_token");
+      setIsLogin(!!token);
+    };
+
+    // 컴포넌트 마운트 시 로그인 상태 체크
+    checkLoginStatus();
+
+    // 커스텀 이벤트 리스너 (같은 탭에서 로그인 상태 변경 감지)
+    const handleLoginStatusChange = () => {
+      checkLoginStatus();
+    };
+
+    window.addEventListener("loginStatusChange", handleLoginStatusChange);
+
+    return () => {
+      window.removeEventListener("loginStatusChange", handleLoginStatusChange);
+    };
+  }, []);
   const { cartData } = useCart();
   const cartCount = cartData.cart_product.length;
+  const { mutate: logoutMutation } = useLogoutMutation();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -70,6 +94,10 @@ const Header = ({
 
   const handleCategoryClick = (category: string) => {
     setSelectedCategory(category);
+  };
+
+  const handleLogout = () => {
+    logoutMutation();
   };
 
   // 카테고리 메뉴 아이템들
@@ -120,14 +148,20 @@ const Header = ({
                 {/* User Actions */}
                 {showUserActions && (
                   <div className="flex items-center gap-3 md:gap-5">
-                    <LoginDialog>
+                    {isLogin ? (
                       <span
                         className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity"
-                        onClick={() => setIsLogin(!isLogin)}
+                        onClick={handleLogout}
                       >
-                        {isLogin ? "로그아웃" : "로그인"}
+                        로그아웃
                       </span>
-                    </LoginDialog>
+                    ) : (
+                      <LoginDialog>
+                        <span className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity">
+                          로그인
+                        </span>
+                      </LoginDialog>
+                    )}
                     <span className="text-black text-[9px] md:text-[10px] font-inter text-center w-6 md:w-8 h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity">
                       도움말
                     </span>

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -26,6 +26,7 @@ type FormType = "login" | "register";
 
 const LoginDialog = ({ children }: LoginDialogProps) => {
   const [currentForm, setCurrentForm] = useState<FormType>("login");
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleSwitchToRegister = () => {
     setCurrentForm("register");
@@ -34,9 +35,15 @@ const LoginDialog = ({ children }: LoginDialogProps) => {
   const handleSwitchToLogin = () => {
     setCurrentForm("login");
   };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
   return (
     <Dialog
+      open={isOpen}
       onOpenChange={(open) => {
+        setIsOpen(open);
         if (open) {
           setCurrentForm("login");
         }
@@ -51,7 +58,7 @@ const LoginDialog = ({ children }: LoginDialogProps) => {
             <div className="space-y-6">
               {/* Conditional Form Rendering */}
               {currentForm === "login" ? (
-                <LoginForm onSwitchToRegister={handleSwitchToRegister} />
+                <LoginForm onSwitchToRegister={handleSwitchToRegister} onClose={handleClose} />
               ) : (
                 <SignupForm onSwitchToLogin={handleSwitchToLogin} />
               )}

--- a/src/components/forms/LoginForm.tsx
+++ b/src/components/forms/LoginForm.tsx
@@ -15,14 +15,16 @@ import { Loader2 } from "lucide-react";
 import { loginSchema, type LoginFormData } from "@/schemas/authSchema";
 import { AxiosError } from "axios";
 import type { AuthErrorResponse } from "@/types/user";
+import { useNavigate } from "react-router-dom";
 
 interface LoginFormProps {
   onSwitchToRegister: () => void;
+  onClose?: () => void;
 }
 
-const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
+const LoginForm = ({ onSwitchToRegister, onClose }: LoginFormProps) => {
   const { mutate: login, isPending, error, isError } = useLoginMutation();
-
+  const navigate = useNavigate();
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
     defaultValues: {
@@ -38,6 +40,7 @@ const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
       onSuccess: () => {
         console.log("로그인 성공");
         toast.success("로그인 성공");
+        onClose?.(); // 다이얼로그 닫기
       },
       onError: (error: any) => {
         if (error.response?.data) {
@@ -106,6 +109,7 @@ const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
             type="submit"
             disabled={isPending || !form.formState.isValid}
             className="h-[48px] w-full bg-[#333333] hover:bg-[#444444] text-white font-inter font-bold text-[16px] leading-[20px] uppercase mt-4"
+            onClick={() => {}}
           >
             {isPending ? (
               <>
@@ -119,10 +123,11 @@ const LoginForm = ({ onSwitchToRegister }: LoginFormProps) => {
 
           {/* Global Error Display */}
           {isError && (
-              <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
-                {error?.response?.data?.message || "로그인 중 오류가 발생했습니다"}
-              </div>
-            )}
+            <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
+              {error?.response?.data?.message ||
+                "로그인 중 오류가 발생했습니다"}
+            </div>
+          )}
 
           {/* Privacy Notice */}
           <p className="font-inter text-[14px] leading-[22px] text-[#5C5C5C] mt-2">

--- a/src/components/forms/SignupForm.tsx
+++ b/src/components/forms/SignupForm.tsx
@@ -6,21 +6,15 @@ import {
   FormField,
   FormItem,
   FormMessage,
+  FormLabel,
 } from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { FileUpload } from "@/components/ui/file-upload";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSignUpMutation } from "@/hooks/useAuth";
 import { signUpSchema, type SignUpFormData } from "@/schemas/authSchema";
-import { toast } from "sonner"; // 또는 사용하는 토스트 라이브러리
+import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
-import { AxiosError } from "axios";
 
 interface SignupFormProps {
   onSwitchToLogin: () => void;
@@ -34,45 +28,53 @@ const SignupForm = ({ onSwitchToLogin }: SignupFormProps) => {
       password: "",
       password2: "",
       email: "",
-      user_gender: "M",
+      profile_image: undefined,
     },
     mode: "onChange", // 실시간 검증
   });
 
   // TanStack Query 뮤테이션 훅 사용
-  const { mutate: signUp, isPending, error } = useSignUpMutation();
+  const { mutate: signUp, isPending } = useSignUpMutation();
 
-  const onSubmit = (values: SignUpFormData) => {
-    // API 명세서에 password2가 포함되어 있으므로 전체 데이터 전송
-    signUp(values, {
-      onSuccess: () => {
-        toast.success("회원가입이 완료되었습니다!");
-        form.reset(); // 폼 초기화
-        onSwitchToLogin(); // 로그인 폼으로 전환
-      },
-      onError: (error: any) => {
-        // DRF 에러 처리
-        if (error.response?.data) {
-          const errorData = error.response.data;
+  const onSubmit = async (values: SignUpFormData) => {
+    try {
+      const submitData = {
+        username: values.username,
+        password: values.password,
+        password2: values.password2,
+        email: values.email,
+        profile_image: values.profile_image && values.profile_image.length > 0 ? values.profile_image[0] : null,
+      };
 
-          // 필드별 에러를 폼에 설정
-          Object.entries(errorData).forEach(([field, messages]) => {
-            if (field in values) {
-              form.setError(field as keyof SignUpFormData, {
-                message: Array.isArray(messages) ? messages[0] : messages,
-              });
+      signUp(submitData, {
+        onSuccess: (data) => {
+          toast.success(data.message || "회원가입이 완료되었습니다!");
+          form.reset();
+          onSwitchToLogin();
+        },
+        onError: (error: any) => {
+          if (error.response?.data) {
+            const errorData = error.response.data;
+
+            Object.entries(errorData).forEach(([field, messages]) => {
+              if (field in values) {
+                form.setError(field as keyof SignUpFormData, {
+                  message: Array.isArray(messages) ? messages[0] : messages,
+                });
+              }
+            });
+
+            if (errorData.detail) {
+              toast.error(errorData.detail);
             }
-          });
-
-          // 일반 에러 메시지
-          if (errorData.detail) {
-            toast.error(errorData.detail);
+          } else {
+            toast.error("회원가입 중 오류가 발생했습니다.");
           }
-        } else {
-          toast.error("회원가입 중 오류가 발생했습니다.");
-        }
-      },
-    });
+        },
+      });
+    } catch (error) {
+      toast.error("회원가입 처리 중 오류가 발생했습니다.");
+    }
   };
 
   return (
@@ -166,26 +168,24 @@ const SignupForm = ({ onSwitchToLogin }: SignupFormProps) => {
             )}
           />
 
-          {/* Gender Select - Select 컴포넌트로 개선 */}
+          {/* Profile Image Upload */}
           <FormField
             control={form.control}
-            name="user_gender"
+            name="profile_image"
             render={({ field }) => (
               <FormItem>
+                <FormLabel className="text-black font-inter text-[14px] font-medium">
+                  Profile Image (선택사항)
+                </FormLabel>
                 <FormControl>
-                  <Select
-                    value={field.value}
-                    onValueChange={field.onChange}
-                    disabled={isPending}
-                  >
-                    <SelectTrigger className="h-[50px] w-full bg-white/30 border border-[#5C5C5C] shadow-[4px_4px_13px_rgba(242,113,144,0.15)] font-inter text-[14px] text-black px-[21px] disabled:opacity-50">
-                      <SelectValue placeholder="Select Gender" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="M">Male</SelectItem>
-                      <SelectItem value="F">Female</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <div className="bg-white/30 border border-[#5C5C5C] shadow-[4px_4px_13px_rgba(242,113,144,0.15)] rounded-md">
+                    <FileUpload
+                      onChange={(files) => {
+                        field.onChange(files);
+                      }}
+                      disabled={isPending}
+                    />
+                  </div>
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -208,17 +208,6 @@ const SignupForm = ({ onSwitchToLogin }: SignupFormProps) => {
             )}
           </Button>
 
-          {/* Global Error Display */}
-          {error &&
-            (error as AxiosError<{ detail: string }>)?.response?.data
-              ?.detail && (
-              <div className="p-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md">
-                {
-                  (error as AxiosError<{ detail: string }>)?.response?.data
-                    ?.detail
-                }
-              </div>
-            )}
 
           {/* Already have account */}
           <button

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -1,0 +1,174 @@
+import { cn } from "@/lib/utils";
+import React, { useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { IconUpload } from "@tabler/icons-react";
+import { useDropzone } from "react-dropzone";
+
+const mainVariant = {
+  initial: {
+    x: 0,
+    y: 0,
+  },
+  animate: {
+    x: 20,
+    y: -20,
+    opacity: 0.9,
+  },
+};
+
+const secondaryVariant = {
+  initial: {
+    opacity: 0,
+  },
+  animate: {
+    opacity: 1,
+  },
+};
+
+export const FileUpload = ({
+  onChange,
+  disabled,
+}: {
+  onChange?: (files: File[]) => void;
+  disabled?: boolean;
+}) => {
+  const [files, setFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (newFiles: File[]) => {
+    setFiles(newFiles);
+    onChange && onChange(newFiles);
+  };
+
+  const handleClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const { getRootProps, isDragActive } = useDropzone({
+    multiple: false,
+    noClick: true,
+    onDrop: handleFileChange,
+    onDropRejected: (error) => {
+      console.log(error);
+    },
+    accept: {
+      "image/*": [".jpeg", ".jpg", ".png", ".gif", ".webp"],
+    },
+    disabled,
+  });
+
+  return (
+    <div className="w-full" {...getRootProps()}>
+      <motion.div
+        onClick={handleClick}
+        whileHover="animate"
+        className="p-10 group/file block rounded-lg cursor-pointer w-full relative overflow-hidden"
+      >
+        <input
+          ref={fileInputRef}
+          id="file-upload-handle"
+          type="file"
+          accept="image/*"
+          onChange={(e) => handleFileChange(Array.from(e.target.files || []))}
+          className="hidden"
+          disabled={disabled}
+        />
+        <div className="flex flex-col items-center justify-center">
+          <p className="relative z-20 font-sans font-bold text-neutral-700 dark:text-neutral-300 text-base">
+            Upload file
+          </p>
+          <p className="relative z-20 font-sans font-normal text-neutral-400 dark:text-neutral-400 text-base mt-2">
+            Drag or drop your files here or click to upload
+          </p>
+          <div className="relative w-full mt-10 max-w-xl mx-auto">
+            {files.length > 0 &&
+              files.map((file, idx) => (
+                <motion.div
+                  key={"file" + idx}
+                  layoutId={idx === 0 ? "file-upload" : "file-upload-" + idx}
+                  className={cn(
+                    "relative overflow-hidden z-40 bg-white dark:bg-neutral-900 flex flex-col items-start justify-start md:h-24 p-4 mt-4 w-full mx-auto rounded-md",
+                    "shadow-sm"
+                  )}
+                >
+                  <div className="flex justify-between w-full items-center gap-4">
+                    <motion.p
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      layout
+                      className="text-base text-neutral-700 dark:text-neutral-300 truncate max-w-xs"
+                    >
+                      {file.name}
+                    </motion.p>
+                    <motion.p
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      layout
+                      className="rounded-lg px-2 py-1 w-fit flex-shrink-0 text-sm text-neutral-600 dark:bg-neutral-800 dark:text-white shadow-input"
+                    >
+                      {(file.size / (1024 * 1024)).toFixed(2)} MB
+                    </motion.p>
+                  </div>
+
+                  <div className="flex text-sm md:flex-row flex-col items-start md:items-center w-full mt-2 justify-between text-neutral-600 dark:text-neutral-400">
+                    <motion.p
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      layout
+                      className="px-1 py-0.5 rounded-md bg-gray-100 dark:bg-neutral-800 "
+                    >
+                      {file.type}
+                    </motion.p>
+
+                    <motion.p
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      layout
+                    >
+                      modified{" "}
+                      {new Date(file.lastModified).toLocaleDateString()}
+                    </motion.p>
+                  </div>
+                </motion.div>
+              ))}
+            {!files.length && (
+              <motion.div
+                layoutId="file-upload"
+                variants={mainVariant}
+                transition={{
+                  type: "spring",
+                  stiffness: 300,
+                  damping: 20,
+                }}
+                className={cn(
+                  "relative group-hover/file:shadow-2xl z-40 bg-white dark:bg-neutral-900 flex items-center justify-center h-32 mt-4 w-full max-w-[8rem] mx-auto rounded-md",
+                  "shadow-[0px_10px_50px_rgba(0,0,0,0.1)]"
+                )}
+              >
+                {isDragActive ? (
+                  <motion.p
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    className="text-neutral-600 flex flex-col items-center"
+                  >
+                    Drop it
+                    <IconUpload className="h-4 w-4 text-neutral-600 dark:text-neutral-400" />
+                  </motion.p>
+                ) : (
+                  <IconUpload className="h-4 w-4 text-neutral-600 dark:text-neutral-300" />
+                )}
+              </motion.div>
+            )}
+
+            {!files.length && (
+              <motion.div
+                variants={secondaryVariant}
+                className="absolute opacity-0 border border-dashed border-sky-400 inset-0 z-30 bg-transparent flex items-center justify-center h-32 mt-4 w-full max-w-[8rem] mx-auto rounded-md"
+              ></motion.div>
+            )}
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,30 +1,19 @@
 import { useMutation } from "@tanstack/react-query";
-import { signUp, login } from "../api/auth";
+import { signUp, login, logout } from "../api/auth";
 import type {
   SignUpRequest,
   SignUpResponse,
   LoginRequest,
   LoginResponse,
+  LogoutResponse,
   AuthErrorResponse,
 } from "../types/user";
 import { AxiosError } from "axios";
 import { useNavigate } from "react-router-dom";
 
 export const useSignUpMutation = () => {
-  const navigate = useNavigate();
   return useMutation<SignUpResponse, AxiosError, SignUpRequest>({
     mutationFn: (userData: SignUpRequest) => signUp(userData),
-    onSuccess: (data) => {
-      // 성공 시
-      console.log("회원가입 성공", data);
-      alert(data.message);
-      navigate("/login");
-    },
-    onError: (error) => {
-      // 실패 시
-      console.log("회원가입 실패", error);
-      alert("회원가입 중 오류가 발생했습니다.");
-    },
   });
 };
 
@@ -40,8 +29,10 @@ export const useLoginMutation = () => {
       // 로그인 성공 시
       console.log("로그인 성공", data);
       alert(data.message);
-      // 로그인 성공 시 토큰 저장
+      // 로그인 성공 시 토큰 저장 (httpOnly 쿠키가 더 안전하지만, 현재는 localStorage 사용)
       localStorage.setItem("access_token", data.access_token);
+      localStorage.setItem("refresh_token", data.refresh_token);
+      window.dispatchEvent(new Event("loginStatusChange"));
       navigate("/");
     },
     onError: (error) => {
@@ -66,6 +57,30 @@ export const useLoginMutation = () => {
         console.log("로그인 실패", error.message);
         alert("로그인 중 알 수 없는 오류가 발생했습니다.");
       }
+    },
+  });
+};
+
+export const useLogoutMutation = () => {
+  const navigate = useNavigate();
+  return useMutation<LogoutResponse, AxiosError<AuthErrorResponse>, void>({
+    mutationFn: () => logout(),
+    onSuccess: (data) => {
+      // 로그아웃 성공 시
+      console.log("로그아웃 성공", data);
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
+      window.dispatchEvent(new Event("loginStatusChange"));
+      navigate("/");
+    },
+    onError: (error) => {
+      // 로그아웃 실패 시
+      console.log("로그아웃 실패", error);
+      // 실패해도 로컬 토큰은 제거
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
+      window.dispatchEvent(new Event("loginStatusChange"));
+      navigate("/");
     },
   });
 };

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -28,7 +28,17 @@ export const signUpSchema = z
 
     password2: z.string().min(1, "비밀번호 확인은 필수입니다"),
 
-    user_gender: z.enum(["M", "F"]),
+    profile_image: z
+      .any()
+      .optional()
+      .refine(
+        (files) => !files || files?.length === 0 || files?.[0]?.size <= 5000000,
+        "파일 크기는 5MB 이하여야 합니다"
+      )
+      .refine(
+        (files) => !files || files?.length === 0 || ["image/jpeg", "image/jpg", "image/png", "image/webp", "image/gif"].includes(files?.[0]?.type),
+        "jpg, jpeg, png, webp, gif 파일만 업로드 가능합니다"
+      ),
   })
   .refine((data) => data.password === data.password2, {
     message: "비밀번호가 일치하지 않습니다",
@@ -36,8 +46,8 @@ export const signUpSchema = z
   });
 
 export const loginSchema = z.object({
-  username: z.string().min(1, "Username is required"),
-  password: z.string().min(1, "Password is required"),
+  username: z.string().min(1, "사용자 이름은 필수입니다"),
+  password: z.string().min(1, "비밀번호는 필수입니다"),
 });
 
 // 타입 추출

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -16,7 +16,7 @@ export interface SignUpRequest {
   password: string;
   password2: string;
   email: string;
-  image: string;
+  profile_image: File | null;
 }
 
 export interface SignUpResponse {
@@ -32,10 +32,16 @@ export interface LoginRequest {
 export interface LoginResponse {
   status: number;
   access_token: string;
+  refresh_token: string;
   message: string;
 }
 
 export interface AuthErrorResponse {
+  status: number;
+  message: string;
+}
+
+export interface LogoutResponse {
   status: number;
   message: string;
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

--- 유저 인증 관련 API 연동

### ✨ Description

<!-- write down the work details and show the execution results. -->

1. 일전에 구현했던 인증 API 연동을 수정함
2. 회원가입 폼의 성별을 이미지 파일 받는 것으로 대체(드래그 앤 드랍)
3. 로그인 시 response body에 refresh_token 추가
4. 로그아웃 시 request body에 refresh_token 추가

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #50 