### PR TITLE
[Fix] 로그아웃 시 쿼리 캐시 삭제, 인증 추가

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -166,7 +166,13 @@ const Header = ({
                     </span>
                     <span
                       className="text-black text-[9px] md:text-[10px] font-inter text-center w-[50px] md:w-[62px] h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity"
-                      onClick={() => navigate("/cart")}
+                      onClick={() => {
+                        if (!isLogin) {
+                          alert("로그인이 필요합니다.");
+                          return;
+                        }
+                        navigate("/cart");
+                      }}
                     >
                       장바구니({cartCount})
                     </span>

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, type ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
 import { 
   useCartQuery, 
   useAddCartItemMutation, 
@@ -17,6 +17,7 @@ interface CartContextType {
   totalPrice: number;
   isLoading: boolean;
   error: Error | null;
+  isAuthenticated: boolean;
   addToCart: (product: Product, quantity: number) => void;
   removeFromCart: (cartProductId: number) => void;
   updateQuantity: (cartProductId: number, quantity: number) => void;
@@ -35,24 +36,68 @@ interface CartProviderProps {
 export const CartProvider = ({ children }: CartProviderProps) => {
   const [directPurchaseProduct, setDirectPurchaseProduct] =
     useState<DirectPurchaseProduct | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   
-  // Use React Query hooks for cart data
+  // Check authentication status
+  useEffect(() => {
+    const checkAuthStatus = () => {
+      const token = localStorage.getItem("access_token");
+      setIsAuthenticated(!!token);
+    };
+
+    checkAuthStatus();
+
+    const handleLoginStatusChange = () => {
+      const token = localStorage.getItem("access_token");
+      const wasAuthenticated = isAuthenticated;
+      
+      if (!token) {
+        // User logged out
+        setIsAuthenticated(false);
+        setDirectPurchaseProduct(null);
+      } else {
+        // User logged in
+        setIsAuthenticated(true);
+        // If this is a fresh login (not just a page refresh), clear direct purchase
+        if (!wasAuthenticated) {
+          setDirectPurchaseProduct(null);
+        }
+      }
+    };
+
+    window.addEventListener("loginStatusChange", handleLoginStatusChange);
+    return () => window.removeEventListener("loginStatusChange", handleLoginStatusChange);
+  }, [isAuthenticated]);
+
+  // Only fetch cart data if authenticated
   const { data: cartData, isLoading, error } = useCartQuery();
   const addCartItemMutation = useAddCartItemMutation();
   const removeCartItemMutation = useRemoveCartItemMutation();
   const updateCartItemMutation = useUpdateCartItemMutation();
 
-  const totalPrice = cartData?.total_price || 0;
+  const totalPrice = isAuthenticated ? (cartData?.total_price || 0) : 0;
 
   const handleAddToCart = (product: Product, quantity: number) => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
     addCartItemMutation.mutate({ productId: product.product_id, quantity });
   };
 
   const handleRemoveFromCart = (cartProductId: number) => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
     removeCartItemMutation.mutate(cartProductId);
   };
 
   const handleUpdateQuantity = (cartProductId: number, quantity: number) => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
     if (quantity <= 0) {
       handleRemoveFromCart(cartProductId);
     } else {
@@ -61,6 +106,10 @@ export const CartProvider = ({ children }: CartProviderProps) => {
   };
 
   const handleIncreaseQuantity = (cartProductId: number) => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
     const currentItem = cartData?.cart_product.find(
       (item) => item.cart_product_id === cartProductId
     );
@@ -70,6 +119,10 @@ export const CartProvider = ({ children }: CartProviderProps) => {
   };
 
   const handleDecreaseQuantity = (cartProductId: number) => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
     const currentItem = cartData?.cart_product.find(
       (item) => item.cart_product_id === cartProductId
     );
@@ -79,10 +132,11 @@ export const CartProvider = ({ children }: CartProviderProps) => {
   };
 
   const value: CartContextType = {
-    cartData,
+    cartData: isAuthenticated ? cartData : undefined,
     totalPrice,
-    isLoading,
-    error: error as Error | null,
+    isLoading: isAuthenticated ? isLoading : false,
+    error: isAuthenticated ? (error as Error | null) : null,
+    isAuthenticated,
     addToCart: handleAddToCart,
     removeFromCart: handleRemoveFromCart,
     updateQuantity: handleUpdateQuantity,

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { signUp, login, logout } from "../api/auth";
 import type {
   SignUpRequest,
@@ -63,6 +63,8 @@ export const useLoginMutation = () => {
 
 export const useLogoutMutation = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  
   return useMutation<LogoutResponse, AxiosError<AuthErrorResponse>, void>({
     mutationFn: () => logout(),
     onSuccess: (data) => {
@@ -70,6 +72,10 @@ export const useLogoutMutation = () => {
       console.log("로그아웃 성공", data);
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
+      
+      // Clear all cart-related cache
+      queryClient.removeQueries({ queryKey: ["cart"] });
+      
       window.dispatchEvent(new Event("loginStatusChange"));
       navigate("/");
     },
@@ -79,6 +85,10 @@ export const useLogoutMutation = () => {
       // 실패해도 로컬 토큰은 제거
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
+      
+      // Clear all cart-related cache even on logout failure
+      queryClient.removeQueries({ queryKey: ["cart"] });
+      
       window.dispatchEvent(new Event("loginStatusChange"));
       navigate("/");
     },

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -2,9 +2,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { addCartItem, removeCartItem, updateCartItem, fetchCartList } from "@/api/cartItems";
 
 export const useCartQuery = () => {
+    const isAuthenticated = !!localStorage.getItem("access_token");
+    
     return useQuery({
-        queryKey: ["cart"],
+        queryKey: ["cart"], // Backend handles user isolation automatically
         queryFn: fetchCartList,
+        enabled: isAuthenticated, // Only fetch when authenticated
         staleTime: 5 * 60 * 1000,
         gcTime: 10 * 60 * 1000,
     });

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,9 +1,24 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import CartProductCard from "@/components/common/CartProductCard";
 import { useCart } from "@/contexts/CartContext";
 
 function Cart() {
-  const { cartData } = useCart();
+  const { cartData, isAuthenticated } = useCart();
+  const navigate = useNavigate();
   const cartItems = cartData?.cart_product;
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요합니다.");
+      navigate("/");
+    }
+  }, [isAuthenticated, navigate]);
+
+  // Don't render if not authenticated
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <div className="min-h-screen bg-white">


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---로그아웃 시 쿼리 캐시 삭제, 인증 추가

### ✨ Description

<!-- write down the work details and show the execution results. -->

 - isAuthenticated 상태 추가
  - 모든 장바구니 작업에 인증 체크 추가
  - 로그인/로그아웃 시 상태 자동 업데이트

  - enabled: isAuthenticated로 인증된 경우만 쿼리 실행

  - 로그아웃 시 장바구니 캐시 완전 제거

  - 장바구니 버튼에 인증 체크 추가

  - 페이지 접근 시 인증 확인

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #71 