### PR TITLE
[Fix] 헤더의 isSticky가 false면 홈 페이지의 pt 옵션을 제거

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,6 +5,7 @@ import { useFilter } from "@/contexts/FilterContext";
 import type { HeaderVariant } from "@/types/variants";
 import { useCart } from "@/contexts/CartContext";
 import { useLogoutMutation } from "@/hooks/useAuth";
+import { useHeaderSticky } from "@/hooks/useHeaderSticky";
 
 interface HeaderProps {
   variant?: HeaderVariant;
@@ -30,7 +31,7 @@ const Header = ({
   const [scrollProgress, setScrollProgress] = useState(0);
   const [lastScrollY, setLastScrollY] = useState(0);
   const [isLogin, setIsLogin] = useState(false);
-  const [isSticky, setIsSticky] = useState(false);
+  const isSticky = useHeaderSticky();
 
   // 로그인 상태 체크
   useEffect(() => {
@@ -63,13 +64,7 @@ const Header = ({
       const scrollDirection = currentScrollY > lastScrollY ? 1 : -1;
       const isHomePage = location.pathname === "/";
 
-      // 홈페이지에서는 비디오 섹션(800px) 높이를 기준으로 sticky 여부 결정
       if (isHomePage) {
-        const videoSectionHeight = 800;
-        const onBoardingHeight = 1000;
-        const stickyThreshold = videoSectionHeight + onBoardingHeight;
-        setIsSticky(currentScrollY >= stickyThreshold);
-
         // 비디오 섹션 내에서의 스크롤 진행도 계산
         const maxScrollDistance = 100;
         const rawProgress = Math.min(currentScrollY / maxScrollDistance, 1);
@@ -83,8 +78,7 @@ const Header = ({
 
         setScrollProgress(adjustedProgress);
       } else {
-        // 다른 페이지에서는 항상 sticky
-        setIsSticky(true);
+        // 다른 페이지에서는 항상 메뉴 숨김
         setScrollProgress(1);
       }
 

--- a/src/hooks/useHeaderSticky.ts
+++ b/src/hooks/useHeaderSticky.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const useHeaderSticky = () => {
+  const [isSticky, setIsSticky] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      const isHomePage = location.pathname === "/";
+
+      if (isHomePage) {
+        const videoSectionHeight = 800;
+        const onBoardingHeight = 1000;
+        const stickyThreshold = videoSectionHeight + onBoardingHeight;
+        setIsSticky(currentScrollY >= stickyThreshold);
+      } else {
+        setIsSticky(true);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll(); // 초기 실행
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [location.pathname]);
+
+  return isSticky;
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import { useProductsQuery } from "@/hooks/useProducts";
 import { startFittingDetail } from "@/api/fittings";
 import { fetchProducts } from "@/api/products";
 import { useFittingResultsPollingMutation } from "@/hooks/useFittings";
+import { useHeaderSticky } from "@/hooks/useHeaderSticky";
 
 const Home = () => {
   const navigate = useNavigate();
@@ -15,6 +16,7 @@ const Home = () => {
   const { showFitting, setShowFitting } = useFittingContext();
   const [isFittingLoading, setIsFittingLoading] = useState(false);
   const [fittingProgress, setFittingProgress] = useState<string>("");
+  const isSticky = useHeaderSticky();
   // API calls commented out for dummy data testing
   const { data: products } = useProductsQuery(showFitting);
   // const { data: categories } = useCategoriesQuery();
@@ -122,7 +124,7 @@ const Home = () => {
   return (
     <div className="w-full bg-white">
       {/* Main Content */}
-      <div className="flex justify-center pt-[200px] md:pt-[260px]">
+      <div className={`flex justify-center ${isSticky ? 'pt-[200px] md:pt-[260px]' : ''}`}>
         <div className="w-full max-w-[1201px] px-4 lg:px-8 xl:px-0">
           {/* Product Grid */}
           <div className="flex flex-col gap-[60px] md:gap-[80px]">


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---헤더의 isSticky가 false면 홈 페이지의 pt 옵션을 제거

### ✨ Description

<!-- write down the work details and show the execution results. -->

홈 페이지를 내리면 헤더가 isSticky가 되었을 때 Home 메인 섹션의 높이가 변화하는 것을 발견.
이를 조건부 스타일로 pt을 조정함으로써 해결.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #87 