### PR TITLE
[Feat] 피팅하기 플로팅 버튼 메인섹션에서만 보이게 수정

### DIFF
--- a/src/components/OnBoarding.tsx
+++ b/src/components/OnBoarding.tsx
@@ -1,6 +1,6 @@
 const OnBoarding = () => {
   return (
-    <div className="w-full h-[1000px] bg-gray-200">
+    <div className="relative z-[60] w-full h-[1000px] bg-gray-200">
       <h1>OnBoarding</h1>
     </div>
   );

--- a/src/components/VideoSection.tsx
+++ b/src/components/VideoSection.tsx
@@ -61,7 +61,7 @@ const VideoSection = ({ onVolumeChange }: VideoSectionProps) => {
   }, [onVolumeChange]);
 
   return (
-    <div ref={sectionRef}>
+    <div ref={sectionRef} className="relative z-[60]">
       <video 
         ref={videoRef}
         autoPlay 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -149,7 +149,7 @@ const Home = () => {
         </div>
       </div>
 
-      {/* 피팅하기 플로팅 버튼 */}
+      {/* 피팅하기 플로팅 버튼 - 동영상/온보딩 섹션이 z-index로 가림 */}
       <div className="fixed flex flex-col gap-1 bottom-6 right-6 z-50">
         {/* 진행 상태 메시지 */}
         {fittingProgress && (


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---[Feat] 피팅하기 플로팅 버튼 메인섹션에서만 보이게 수정

### ✨ Description

<!-- write down the work details and show the execution results. -->

온보딩, 비디오 섹션에 z-index를 플로팅 버튼보다 높게 설정하여, 플로팅 버튼이 가려지게 수정.

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #89 