### PR TITLE
[Fix] 헤더 스타일 버그, 주문 요약 이미지 안보임 해결

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -121,12 +121,12 @@ const Header = ({
       className={`${
         isHomePage && !isSticky 
           ? "relative bg-transparent" 
-          : "fixed top-0 left-0 bg-white/70"
+          : "fixed top-0 left-0 bg-transparent"
       } w-full z-50 hover:bg-white/70 group transition-all duration-300`}
     >
       {/* Main Header */}
       <div className="flex items-center justify-center py-5">
-        <div className="w-full max-w-[1329px] px-4 lg:px-8 xl:px-0">
+        <div className="w-full max-w-[1440px] px-4 lg:px-8 xl:px-0">
           <div className="flex items-center justify-between">
             {/* Logo */}
             <div className="flex items-center">

--- a/src/config/layoutConfig.ts
+++ b/src/config/layoutConfig.ts
@@ -71,7 +71,7 @@ export const DYNAMIC_LAYOUT_CONFIG: RoutePattern[] = [
     config: {
       header: "detail",
       footer: "default",
-      showSearch: true,
+      showSearch: false,
       showUserActions: true,
       showNavigation: false,
       title: "상품 상세",

--- a/src/pages/OrderSummary.tsx
+++ b/src/pages/OrderSummary.tsx
@@ -47,6 +47,14 @@ function OrderSummary() {
 
           {/* 상품 이미지들 */}
           <div className="flex gap-10 mb-16">
+            {isDirectPurchase && (
+              <img
+                key={directPurchaseProduct.product_id}
+                className="w-[118px] h-[178px] bg-gray-200 rounded"
+                src={directPurchaseProduct.image}
+                alt={directPurchaseProduct.name}
+              />
+            )}
             {cartData?.cart_product.map((product) => (
               <img
                 key={product.cart_product_id}


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---헤더 스타일 버그, 주문 요약 이미지 안보임 해결

### ✨ Description

<!-- write down the work details and show the execution results. -->

1. 헤더에서 홈 페이지가 아닐 때의 배경 색이 달랐음. 해결
2. 주문 요약 페이지에서 이미지를 장바구니 이미지만 받고 있었음. 해결

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #91 