### PR TITLE
[Feat] 마이페이지 데이터 전달, 수정 기능 구현

### DIFF
--- a/src/components/forms/AddressManagement.tsx
+++ b/src/components/forms/AddressManagement.tsx
@@ -22,8 +22,8 @@ const addressSchema = z.object({
   zipcode: z.string().min(5, { message: "우편번호를 입력해주세요." }),
   address1: z.string().min(1, { message: "기본 주소를 입력해주세요." }),
   address2: z.string().optional(),
-  phone: z.string().regex(/^010-\d{4}-\d{4}$/, {
-    message: "전화번호 형식은 010-0000-0000 이어야 합니다.",
+  phone: z.string().regex(/^\d{10,11}$/, {
+    message: "전화번호는 숫자로만 이루어져야 합니다.",
   }),
   isDefault: z.boolean().default(false),
 });
@@ -34,36 +34,26 @@ interface Address extends AddressFormData {
   id: string;
 }
 
-// Mock addresses data
-const mockAddresses: Address[] = [
-  {
-    id: "1",
-    name: "집",
-    recipient: "홍길동",
-    zipcode: "06142",
-    address1: "서울시 강남구 테헤란로 123",
-    address2: "A동 101호",
-    phone: "010-1234-5678",
-    isDefault: true,
-  },
-  {
-    id: "2",
-    name: "회사",
-    recipient: "홍길동",
-    zipcode: "06543",
-    address1: "서울시 서초구 강남대로 456",
-    address2: "",
-    phone: "010-1234-5678",
-    isDefault: false,
-  },
-];
-
 interface AddressManagementProps {
   onClose: () => void;
+  onAddressUpdate?: ((addresses: Address[]) => void) | null;
+  initialAddresses?: Address[];
 }
 
-const AddressManagement = ({ onClose }: AddressManagementProps) => {
-  const [addresses, setAddresses] = useState<Address[]>(mockAddresses);
+const AddressManagement = ({
+  onClose,
+  onAddressUpdate,
+  initialAddresses = [],
+}: AddressManagementProps) => {
+  const [addresses, setAddressesState] = useState<Address[]>(initialAddresses);
+
+  // addresses 업데이트 시 콜백도 함께 호출
+  const setAddresses = (newAddresses: Address[]) => {
+    setAddressesState(newAddresses);
+    if (onAddressUpdate) {
+      onAddressUpdate(newAddresses);
+    }
+  };
   const [editingAddress, setEditingAddress] = useState<Address | null>(null);
   const [isAdding, setIsAdding] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/components/forms/PersonalInfoForm.tsx
+++ b/src/components/forms/PersonalInfoForm.tsx
@@ -16,12 +16,15 @@ import { useState } from "react";
 
 const personalInfoSchema = z.object({
   name: z.string().min(2, { message: "이름은 2글자 이상이어야 합니다." }),
-  username: z.string().min(3, { message: "사용자명은 3글자 이상이어야 합니다." }).regex(/^[a-zA-Z0-9_]+$/, {
-    message: "사용자명은 영문, 숫자, 밑줄(_)만 사용 가능합니다."
-  }),
+  username: z
+    .string()
+    .min(3, { message: "사용자명은 3글자 이상이어야 합니다." })
+    .regex(/^[a-zA-Z0-9_]+$/, {
+      message: "사용자명은 영문, 숫자, 밑줄(_)만 사용 가능합니다.",
+    }),
   email: z.string().email({ message: "유효한 이메일 주소를 입력해주세요." }),
-  phone: z.string().regex(/^010-\d{4}-\d{4}$/, {
-    message: "전화번호 형식은 010-0000-0000 이어야 합니다.",
+  phone: z.string().regex(/^\d{10,11}$/, {
+    message: "전화번호는 숫자로만 이루어져야 합니다.",
   }),
 });
 
@@ -38,13 +41,13 @@ interface PersonalInfoFormProps {
   onSubmit?: (data: PersonalInfoFormData) => Promise<void>;
 }
 
-const PersonalInfoForm = ({ 
-  initialData = { name: "", username: "", email: "", phone: "" }, 
+const PersonalInfoForm = ({
+  initialData = { name: "", username: "", email: "", phone: "" },
   onClose,
-  onSubmit
+  onSubmit,
 }: PersonalInfoFormProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+
   const form = useForm<PersonalInfoFormData>({
     resolver: zodResolver(personalInfoSchema),
     defaultValues: {
@@ -58,15 +61,15 @@ const PersonalInfoForm = ({
   const handleSubmit = async (data: PersonalInfoFormData) => {
     try {
       setIsSubmitting(true);
-      
+
       if (onSubmit) {
         await onSubmit(data);
       } else {
         // Mock 업데이트 - 실제로는 auth context나 API 호출
         console.log("개인정보 업데이트:", data);
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Mock delay
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // Mock delay
       }
-      
+
       onClose();
     } catch (error) {
       console.error("개인정보 업데이트 실패:", error);
@@ -84,7 +87,10 @@ const PersonalInfoForm = ({
       </CardHeader>
       <CardContent>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+          >
             <FormField
               control={form.control}
               name="name"
@@ -98,7 +104,7 @@ const PersonalInfoForm = ({
                 </FormItem>
               )}
             />
-            
+
             <FormField
               control={form.control}
               name="username"
@@ -112,7 +118,7 @@ const PersonalInfoForm = ({
                 </FormItem>
               )}
             />
-            
+
             <FormField
               control={form.control}
               name="email"
@@ -120,13 +126,17 @@ const PersonalInfoForm = ({
                 <FormItem>
                   <FormLabel>이메일</FormLabel>
                   <FormControl>
-                    <Input {...field} type="email" placeholder="이메일을 입력해주세요" />
+                    <Input
+                      {...field}
+                      type="email"
+                      placeholder="이메일을 입력해주세요"
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
-            
+
             <FormField
               control={form.control}
               name="phone"
@@ -140,11 +150,11 @@ const PersonalInfoForm = ({
                 </FormItem>
               )}
             />
-            
+
             <div className="flex justify-end space-x-2 pt-4">
-              <Button 
-                type="button" 
-                variant="outline" 
+              <Button
+                type="button"
+                variant="outline"
                 onClick={onClose}
                 disabled={isSubmitting}
               >

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -1,51 +1,46 @@
 import { useState, memo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { useModal } from "@/contexts/ModalContext";
+import { useOrder } from "@/contexts/OrderContext";
+import { formatPhoneNumber } from "@/lib/utils";
 import ProfileImage from "@/components/common/ProfileImage";
 import VirtualFittingVideos from "@/components/sections/VirtualFittingVideos";
 
-// Mock user data - 실제로는 auth context에서 가져올 데이터
-const mockUser = {
-  name: "홍길동",
-  username: "hong_gildong",
-  email: "user@example.com",
-  phone: "010-1234-5678",
-  profileImage: null as string | null, // 프로필 이미지 URL
-  addresses: [
-    {
-      id: "1",
-      name: "집",
-      recipient: "홍길동",
-      full: "서울시 강남구 테헤란로 123",
-      zipcode: "06142",
-      phone: "010-1234-5678",
-      isDefault: true,
-    },
-    {
-      id: "2",
-      name: "회사",
-      recipient: "홍길동",
-      full: "서울시 서초구 강남대로 456",
-      zipcode: "06543",
-      phone: "010-1234-5678",
-      isDefault: false,
-    },
-  ],
-};
 
 interface ProfileSectionProps {
   onEditSection?: (section: string) => void;
 }
 
+interface PersonalInfo {
+  name: string;
+  username: string;
+  email: string;
+  phone: string;
+}
+
 const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
-  const [user, setUser] = useState(mockUser); // 실제로는 useAuth 등에서 가져옴
+  const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [personalInfo, setPersonalInfo] = useState<PersonalInfo | null>(null);
   const { openModal } = useModal();
+  const { currentBuyerInfo } = useOrder();
 
   const handleEditClick = (section: string) => {
     if (section === "personalInfo") {
-      openModal("personalInfo");
+      // 현재 표시된 데이터를 PersonalInfoForm의 초기값으로 전달
+      const currentData = {
+        name: personalInfo?.name || currentBuyerInfo?.name || "",
+        username: personalInfo?.username || "",
+        email: personalInfo?.email || "",
+        phone: personalInfo?.phone || currentBuyerInfo?.phone || "",
+      };
+      
+      // PersonalInfoForm에서 제출했을 때 personalInfo 상태 업데이트
+      const handlePersonalInfoSubmit = (data: PersonalInfo) => {
+        setPersonalInfo(data);
+      };
+      
+      openModal("personalInfo", currentData, handlePersonalInfoSubmit);
     } else if (section === "addresses") {
       openModal("addresses");
     }
@@ -53,10 +48,7 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
   };
 
   const handleProfileImageChange = (imageUrl: string | null) => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      profileImage: imageUrl,
-    }));
+    setProfileImage(imageUrl);
     // 실제로는 auth context나 API를 통해 서버에 저장
     console.log("프로필 이미지 업데이트:", imageUrl);
   };
@@ -69,8 +61,8 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
         {/* 프로필 이미지 섹션 */}
         <div className="flex justify-center items-center mb-6 w-[400px]">
           <ProfileImage
-            currentImage={user?.profileImage || undefined}
-            userName={user?.name}
+            currentImage={profileImage || undefined}
+            userName={personalInfo?.name || currentBuyerInfo?.name || "사용자"}
             onImageChange={handleProfileImageChange}
             size="lg"
           />
@@ -85,20 +77,20 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">이름</span>
                 <span className="text-gray-900 font-medium">
-                  {user?.name || "-"}
+                  {personalInfo?.name || currentBuyerInfo?.name || "-"}
                 </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">사용자명</span>
-                <span className="text-gray-900">{user?.username || "-"}</span>
+                <span className="text-gray-900">{personalInfo?.username || "-"}</span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">이메일</span>
-                <span className="text-gray-900">{user?.email || "-"}</span>
+                <span className="text-gray-900">{personalInfo?.email || "-"}</span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">전화번호</span>
-                <span className="text-gray-900">{user?.phone || "-"}</span>
+                <span className="text-gray-900">{formatPhoneNumber(personalInfo?.phone || currentBuyerInfo?.phone || "")}</span>
               </div>
             </div>
             <div className="mt-4 pt-4 border-t">
@@ -122,30 +114,31 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
           <CardTitle className="text-lg">배송지 관리</CardTitle>
         </CardHeader>
         <CardContent>
-          {user?.addresses && user.addresses.length > 0 ? (
+          {currentBuyerInfo ? (
             <div className="space-y-4">
-              {user.addresses.map((address, index) => (
-                <div key={address.id || index}>
-                  {index > 0 && <Separator className="my-3" />}
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium text-gray-900">
-                        {address.name}
-                      </span>
-                      {address.isDefault && (
-                        <span className="bg-black text-white text-xs px-2 py-1 rounded">
-                          기본 배송지
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-sm text-gray-600">{address.recipient}</p>
-                    <p className="text-sm text-gray-500">{address.full}</p>
-                    <p className="text-xs text-gray-400">
-                      {address.zipcode} | {address.phone}
-                    </p>
+              <div>
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-gray-900">
+                      기본 주소
+                    </span>
+                    <span className="bg-black text-white text-xs px-2 py-1 rounded">
+                      기본 배송지
+                    </span>
                   </div>
+                  <p className="text-sm text-gray-600">{currentBuyerInfo.name}</p>
+                  <p className="text-sm text-gray-500">
+                    {currentBuyerInfo.address}
+                    {currentBuyerInfo.address2 && `, ${currentBuyerInfo.address2}`}
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    {currentBuyerInfo.postalCode} | {formatPhoneNumber(currentBuyerInfo.phone)}
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    {currentBuyerInfo.region} ({currentBuyerInfo.regionCode})
+                  </p>
                 </div>
-              ))}
+              </div>
             </div>
           ) : (
             <p className="text-gray-500 text-center py-4">

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -19,11 +19,37 @@ interface PersonalInfo {
   phone: string;
 }
 
+interface Address {
+  id: string;
+  name: string;
+  recipient: string;
+  zipcode: string;
+  address1: string;
+  address2?: string;
+  phone: string;
+  isDefault: boolean;
+}
+
 const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
   const [profileImage, setProfileImage] = useState<string | null>(null);
   const [personalInfo, setPersonalInfo] = useState<PersonalInfo | null>(null);
+  const [addresses, setAddresses] = useState<Address[]>([]);
   const { openModal } = useModal();
   const { currentBuyerInfo } = useOrder();
+
+  // BuyerInfo를 Address 형식으로 변환하는 함수
+  const convertBuyerInfoToAddress = (buyerInfo: typeof currentBuyerInfo): Address => {
+    return {
+      id: "temp_buyer_address", // 임시 ID
+      name: "기본 주소 (주문 정보에서)",
+      recipient: buyerInfo!.name,
+      zipcode: buyerInfo!.postalCode,
+      address1: buyerInfo!.address,
+      address2: buyerInfo!.address2 || "",
+      phone: buyerInfo!.phone,
+      isDefault: true,
+    };
+  };
 
   const handleEditClick = (section: string) => {
     if (section === "personalInfo") {
@@ -42,7 +68,24 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
       
       openModal("personalInfo", currentData, handlePersonalInfoSubmit);
     } else if (section === "addresses") {
-      openModal("addresses");
+      // AddressManagement에서 주소 변경 시 호출될 콜백
+      const handleAddressSubmit = (updatedAddresses: Address[]) => {
+        setAddresses(updatedAddresses);
+      };
+      
+      // 초기 주소 데이터 준비
+      let initialAddressData: Address[] = [];
+      
+      // 1. 사용자가 저장한 주소가 있으면 그것을 사용
+      if (addresses.length > 0) {
+        initialAddressData = addresses;
+      }
+      // 2. 없으면 currentBuyerInfo를 Address 형식으로 변환하여 사용
+      else if (currentBuyerInfo) {
+        initialAddressData = [convertBuyerInfoToAddress(currentBuyerInfo)];
+      }
+      
+      openModal("addresses", undefined, undefined, handleAddressSubmit, initialAddressData);
     }
     onEditSection?.(section);
   };
@@ -114,16 +157,44 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
           <CardTitle className="text-lg">배송지 관리</CardTitle>
         </CardHeader>
         <CardContent>
-          {currentBuyerInfo ? (
+          {addresses.length > 0 ? (
+            <div className="space-y-4">
+              {addresses.map((address, index) => (
+                <div key={address.id}>
+                  {index > 0 && <div className="border-t pt-4" />}
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-900">
+                        {address.name}
+                      </span>
+                      {address.isDefault && (
+                        <span className="bg-black text-white text-xs px-2 py-1 rounded">
+                          기본 배송지
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-600">{address.recipient}</p>
+                    <p className="text-sm text-gray-500">
+                      {address.address1}
+                      {address.address2 && `, ${address.address2}`}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      {address.zipcode} | {formatPhoneNumber(address.phone)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : currentBuyerInfo ? (
             <div className="space-y-4">
               <div>
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
                     <span className="font-medium text-gray-900">
-                      기본 주소
+                      기본 주소 (주문 정보에서)
                     </span>
-                    <span className="bg-black text-white text-xs px-2 py-1 rounded">
-                      기본 배송지
+                    <span className="bg-gray-500 text-white text-xs px-2 py-1 rounded">
+                      임시 배송지
                     </span>
                   </div>
                   <p className="text-sm text-gray-600">{currentBuyerInfo.name}</p>

--- a/src/components/sections/RecentOrders.tsx
+++ b/src/components/sections/RecentOrders.tsx
@@ -7,7 +7,7 @@ import { memo, useMemo } from "react";
 const RecentOrders = memo(() => {
   const { orderHistory } = useOrder();
   const navigate = useNavigate();
-  
+
   // 최근 3개 주문만 메모이제이션
   const recentOrders = useMemo(() => {
     return orderHistory.slice(0, 3);
@@ -19,7 +19,7 @@ const RecentOrders = memo(() => {
         <h2 className="text-xl font-semibold mb-4">최근 주문 내역</h2>
         <div className="text-center py-8 text-gray-500">
           <p className="mb-4">최근 주문 내역이 없습니다.</p>
-          <Button 
+          <Button
             onClick={() => navigate("/")}
             className="bg-black text-white hover:bg-gray-800"
           >
@@ -34,21 +34,15 @@ const RecentOrders = memo(() => {
     <div className="bg-white p-6 rounded-lg border border-gray-200">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold">최근 주문 내역</h2>
-        <Button 
-          variant="link" 
-          onClick={() => navigate("/history")}
-          className="text-black hover:text-gray-600 p-0 h-auto font-normal text-sm"
-        >
-          모든 주문 보기 →
-        </Button>
       </div>
-      
+
       <div className="space-y-4">
         {recentOrders.map((order) => (
           <Card key={order.id} className="border border-gray-200">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium text-gray-900">
-                주문번호: {order.orderNumber} | {new Date(order.orderDate).toLocaleDateString('ko-KR')}
+                주문번호: {order.orderNumber} |{" "}
+                {new Date(order.orderDate).toLocaleDateString("ko-KR")}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -58,8 +52,12 @@ const RecentOrders = memo(() => {
                     {order.products.length}개 상품
                   </p>
                   <p className="text-xs text-gray-500">
-                    {order.products.slice(0, 2).map(item => item.name).join(', ')}
-                    {order.products.length > 2 && ` 외 ${order.products.length - 2}개`}
+                    {order.products
+                      .slice(0, 2)
+                      .map((item) => item.name)
+                      .join(", ")}
+                    {order.products.length > 2 &&
+                      ` 외 ${order.products.length - 2}개`}
                   </p>
                 </div>
                 <div className="text-right">
@@ -67,9 +65,9 @@ const RecentOrders = memo(() => {
                     {order.totalPrice.toLocaleString()}원
                   </p>
                   <p className="text-xs text-gray-500 mt-1">
-                    {order.status === 'completed' && '주문완료'}
-                    {order.status === 'shipping' && '배송중'}
-                    {order.status === 'delivered' && '배송완료'}
+                    {order.status === "completed" && "주문완료"}
+                    {order.status === "shipping" && "배송중"}
+                    {order.status === "delivered" && "배송완료"}
                   </p>
                 </div>
               </div>

--- a/src/components/sections/VirtualFittingVideos.tsx
+++ b/src/components/sections/VirtualFittingVideos.tsx
@@ -1,98 +1,88 @@
-import { useState, memo } from "react";
+import { memo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Play, Download, Trash2 } from "lucide-react";
-
-// Mock 가상피팅 영상 데이터
-const mockVirtualFittingVideos = [
-  {
-    id: "1",
-    productName: "클래식 데님 재킷",
-    videoUrl: "/api/videos/fitting-1.mp4", // 실제로는 서버에서 제공되는 URL
-    thumbnailUrl: "/api/thumbnails/fitting-1.jpg",
-    createdAt: "2024-01-15T10:30:00Z",
-    duration: 45, // 초 단위
-    size: "M",
-    color: "인디고 블루",
-  },
-  {
-    id: "2",
-    productName: "오버사이즈 후드티",
-    videoUrl: "/api/videos/fitting-2.mp4",
-    thumbnailUrl: "/api/thumbnails/fitting-2.jpg",
-    createdAt: "2024-01-12T14:20:00Z",
-    duration: 38,
-    size: "L",
-    color: "차콜 그레이",
-  },
-  {
-    id: "3",
-    productName: "슬림핏 정장 바지",
-    videoUrl: "/api/videos/fitting-3.mp4",
-    thumbnailUrl: "/api/thumbnails/fitting-3.jpg",
-    createdAt: "2024-01-10T09:15:00Z",
-    duration: 52,
-    size: "32",
-    color: "네이비",
-  },
-  {
-    id: "4",
-    productName: "코튼 블렌드 셔츠",
-    videoUrl: "/api/videos/fitting-4.mp4",
-    thumbnailUrl: "/api/thumbnails/fitting-4.jpg",
-    createdAt: "2024-01-08T16:45:00Z",
-    duration: 41,
-    size: "L",
-    color: "화이트",
-  },
-];
+import { Play, Download, Trash2, Loader2 } from "lucide-react";
+import { useFittingVideos } from "@/hooks/useFittings";
 
 const VirtualFittingVideos = memo(() => {
-  const [videos, setVideos] = useState(mockVirtualFittingVideos);
+  const { data: fittingVideos, isLoading, error } = useFittingVideos();
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
-
-  const handlePlayVideo = (videoId: string) => {
+  const handlePlayVideo = (videoUrl: string, productName: string) => {
     // 실제로는 비디오 플레이어 모달을 열어야 함
-    console.log("재생할 영상:", videoId);
+    console.log("재생할 영상:", productName, videoUrl);
+    // 임시로 새 탭에서 영상 열기
+    window.open(videoUrl, "_blank");
   };
 
-  const handleDownloadVideo = (videoId: string) => {
-    const video = videos.find((v) => v.id === videoId);
-    if (video) {
-      // 실제로는 서버에서 영상 다운로드 링크 제공
-      console.log("다운로드할 영상:", video.productName);
-      // 임시로 alert 표시
-      alert(`"${video.productName}" 가상피팅 영상 다운로드를 시작합니다.`);
+  const handleDownloadVideo = (videoUrl: string, productName: string) => {
+    // 실제로는 서버에서 영상 다운로드 링크 제공
+    console.log("다운로드할 영상:", productName, videoUrl);
+    // 임시로 alert 표시
+    alert(`"${productName}" 가상피팅 영상 다운로드를 시작합니다.`);
+
+    // 다운로드 링크 생성 (임시)
+    const link = document.createElement("a");
+    link.href = videoUrl;
+    link.download = `${productName}_fitting_video.mp4`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const handleDeleteVideo = (productId: number, productName: string) => {
+    if (confirm(`"${productName}" 가상피팅 영상을 삭제하시겠습니까?`)) {
+      // 실제로는 서버에 삭제 요청을 보내야 함
+      console.log("삭제할 영상:", productId, productName);
+      alert("영상 삭제 기능은 아직 구현되지 않았습니다.");
     }
   };
 
-  const handleDeleteVideo = (videoId: string) => {
-    const video = videos.find((v) => v.id === videoId);
-    if (
-      video &&
-      confirm(`"${video.productName}" 가상피팅 영상을 삭제하시겠습니까?`)
-    ) {
-      setVideos((prevVideos) => prevVideos.filter((v) => v.id !== videoId));
-      // 실제로는 서버에 삭제 요청
-    }
-  };
-
-  if (videos.length === 0) {
+  // 로딩 상태
+  if (isLoading) {
     return (
-      <Card className="mb-4">
+      <Card className="mb-10">
+        <CardHeader>
+          <CardTitle className="text-lg">가상피팅 영상</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-8">
+            <Loader2 className="w-8 h-8 animate-spin mx-auto mb-4 text-gray-400" />
+            <p className="text-gray-500">가상피팅 영상을 불러오는 중...</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <Card className="mb-10">
+        <CardHeader>
+          <CardTitle className="text-lg">가상피팅 영상</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-8 text-red-500">
+            <p className="mb-4">가상피팅 영상을 불러오는데 실패했습니다.</p>
+            <Button onClick={() => window.location.reload()} variant="outline">
+              다시 시도
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // 영상이 없는 상태
+  if (!fittingVideos || fittingVideos.length === 0) {
+    return (
+      <Card className="mb-10">
         <CardHeader>
           <CardTitle className="text-lg">가상피팅 영상</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-center py-8 text-gray-500">
-            <p className="mb-4">아직 가상피팅을 진행한 상품이 없습니다.</p>
+            <p className="mb-4">아직 완성된 가상피팅 영상이 없습니다.</p>
             <Button
               onClick={() => (window.location.href = "/")}
               className="bg-black text-white hover:bg-gray-800"
@@ -117,20 +107,23 @@ const VirtualFittingVideos = memo(() => {
         {/* 가로 스크롤 컨테이너 */}
         <div className="overflow-x-auto">
           <div className="flex gap-4 pb-2" style={{ minWidth: "max-content" }}>
-            {videos.map((video) => (
-              <div key={video.id} className="flex-shrink-0">
+            {fittingVideos.map((video) => (
+              <div key={video.product_id} className="flex-shrink-0">
                 {/* 썸네일 영역 - Detail.tsx 메인 이미지와 같은 비율 (532:800 = 2:3) */}
                 <div className="relative w-32 h-48 bg-gray-100 rounded-lg overflow-hidden group cursor-pointer mb-3">
-                  {/* 실제로는 video.thumbnailUrl 사용 */}
+                  {/* 영상 썸네일 (실제로는 영상에서 추출하거나 별도 API로 제공) */}
                   <div className="w-full h-full bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
-                    {/* 기본 상품 이미지 역할 */}
-                    <div className="w-full h-full bg-gray-300"></div>
+                    <div className="w-full h-full bg-gray-300 flex items-center justify-center">
+                      <Play className="w-8 h-8 text-gray-500" />
+                    </div>
                   </div>
 
                   {/* 호버시 나타나는 플레이 버튼 */}
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-black bg-opacity-30">
                     <button
-                      onClick={() => handlePlayVideo(video.id)}
+                      onClick={() =>
+                        handlePlayVideo(video.video_url, video.product_name)
+                      }
                       className="bg-white bg-opacity-90 hover:bg-white text-black rounded-full p-3 transition-all duration-200 hover:scale-110"
                     >
                       <Play className="w-6 h-6 fill-current" />
@@ -141,18 +134,18 @@ const VirtualFittingVideos = memo(() => {
                 {/* 영상 정보 */}
                 <div className="w-32">
                   <h4 className="font-medium text-gray-900 text-sm mb-2 line-clamp-2">
-                    {video.productName}
+                    {video.product_name}
                   </h4>
-                  <p className="text-xs text-gray-500 mb-3">
-                    {formatDate(video.createdAt)}
-                  </p>
+                  <p className="text-xs text-gray-500 mb-3">가상피팅 완료</p>
 
                   {/* 액션 버튼들 */}
                   <div className="flex gap-1">
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => handleDownloadVideo(video.id)}
+                      onClick={() =>
+                        handleDownloadVideo(video.video_url, video.product_name)
+                      }
                       className="h-7 w-7 p-0 flex-shrink-0"
                       title="다운로드"
                     >
@@ -161,7 +154,9 @@ const VirtualFittingVideos = memo(() => {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => handleDeleteVideo(video.id)}
+                      onClick={() =>
+                        handleDeleteVideo(video.product_id, video.product_name)
+                      }
                       className="h-7 w-7 p-0 text-red-600 hover:text-red-700 flex-shrink-0"
                       title="삭제"
                     >
@@ -174,10 +169,10 @@ const VirtualFittingVideos = memo(() => {
           </div>
         </div>
 
-        {videos.length > 4 && (
+        {fittingVideos.length > 4 && (
           <div className="mt-4 pt-4 border-t">
             <Button variant="outline" size="sm" className="w-full">
-              모든 영상 보기 ({videos.length}개)
+              모든 영상 보기 ({fittingVideos.length}개)
             </Button>
           </div>
         )}

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -19,8 +19,25 @@ type PersonalInfoData = {
   phone: string;
 };
 
+type Address = {
+  id: string;
+  name: string;
+  recipient: string;
+  zipcode: string;
+  address1: string;
+  address2?: string;
+  phone: string;
+  isDefault: boolean;
+};
+
 type ModalContextType = {
-  openModal: (type: ModalType, initialData?: PersonalInfoData, onSubmitCallback?: (data: PersonalInfoData) => void) => void;
+  openModal: (
+    type: ModalType, 
+    initialData?: PersonalInfoData, 
+    onSubmitCallback?: (data: PersonalInfoData) => void,
+    onAddressCallback?: (addresses: Address[]) => void,
+    initialAddresses?: Address[]
+  ) => void;
   closeModal: () => void;
   modalType: ModalType;
 };
@@ -31,17 +48,29 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
   const [modalType, setModalType] = useState<ModalType>(null);
   const [initialData, setInitialData] = useState<PersonalInfoData | null>(null);
   const [submitCallback, setSubmitCallback] = useState<((data: PersonalInfoData) => void) | null>(null);
+  const [addressCallback, setAddressCallback] = useState<((addresses: Address[]) => void) | null>(null);
+  const [initialAddresses, setInitialAddresses] = useState<Address[]>([]);
 
-  const openModal = (type: ModalType, data?: PersonalInfoData, onSubmitCallback?: (data: PersonalInfoData) => void) => {
+  const openModal = (
+    type: ModalType, 
+    data?: PersonalInfoData, 
+    onSubmitCallback?: (data: PersonalInfoData) => void,
+    onAddressCallback?: (addresses: Address[]) => void,
+    initialAddressData?: Address[]
+  ) => {
     setModalType(type);
     setInitialData(data || null);
     setSubmitCallback(() => onSubmitCallback || null);
+    setAddressCallback(() => onAddressCallback || null);
+    setInitialAddresses(initialAddressData || []);
   };
 
   const closeModal = () => {
     setModalType(null);
     setInitialData(null);
     setSubmitCallback(null);
+    setAddressCallback(null);
+    setInitialAddresses([]);
   };
 
   // Default data for forms when no initial data is provided
@@ -88,7 +117,11 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
               />
             )}
             {modalType === "addresses" && (
-              <AddressManagement onClose={closeModal} />
+              <AddressManagement 
+                onClose={closeModal}
+                onAddressUpdate={addressCallback}
+                initialAddresses={initialAddresses}
+              />
             )}
           </Suspense>
         </DialogContent>

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -12,8 +12,15 @@ const AddressManagement = lazy(
 
 type ModalType = "personalInfo" | "addresses" | null;
 
+type PersonalInfoData = {
+  name: string;
+  username: string;
+  email: string;
+  phone: string;
+};
+
 type ModalContextType = {
-  openModal: (type: ModalType) => void;
+  openModal: (type: ModalType, initialData?: PersonalInfoData, onSubmitCallback?: (data: PersonalInfoData) => void) => void;
   closeModal: () => void;
   modalType: ModalType;
 };
@@ -22,21 +29,27 @@ const ModalContext = createContext<ModalContextType | undefined>(undefined);
 
 export const ModalProvider = ({ children }: { children: ReactNode }) => {
   const [modalType, setModalType] = useState<ModalType>(null);
+  const [initialData, setInitialData] = useState<PersonalInfoData | null>(null);
+  const [submitCallback, setSubmitCallback] = useState<((data: PersonalInfoData) => void) | null>(null);
 
-  const openModal = (type: ModalType) => {
+  const openModal = (type: ModalType, data?: PersonalInfoData, onSubmitCallback?: (data: PersonalInfoData) => void) => {
     setModalType(type);
+    setInitialData(data || null);
+    setSubmitCallback(() => onSubmitCallback || null);
   };
 
   const closeModal = () => {
     setModalType(null);
+    setInitialData(null);
+    setSubmitCallback(null);
   };
 
-  // Mock user data for forms
-  const mockUserData = {
-    name: "홍길동",
-    username: "hong_gildong",
-    email: "user@example.com",
-    phone: "010-1234-5678",
+  // Default data for forms when no initial data is provided
+  const defaultUserData = {
+    name: "",
+    username: "",
+    email: "",
+    phone: "",
   };
 
   return (
@@ -59,11 +72,17 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
           >
             {modalType === "personalInfo" && (
               <PersonalInfoForm
-                initialData={mockUserData}
+                initialData={initialData || defaultUserData}
                 onClose={closeModal}
                 onSubmit={async (data) => {
                   console.log("개인정보 업데이트:", data);
-                  // 실제로는 auth context나 API 호출
+                  
+                  // ProfileSection의 setPersonalInfo 콜백 호출
+                  if (submitCallback) {
+                    submitCallback(data);
+                  }
+                  
+                  // Mock delay
                   await new Promise((resolve) => setTimeout(resolve, 1000));
                 }}
               />

--- a/src/hooks/useFittings.ts
+++ b/src/hooks/useFittings.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { generateFittingVideo, getFittingVideoStatus } from "../api/fittings";
 import { fetchProducts } from "../api/products";
 import type { FittingVideoStatusResponse } from "../api/fittings";
@@ -141,5 +141,61 @@ export const useFittingResultsPollingMutation = () => {
         console.error("피팅 결과 조회 실패:", error);
       }
     },
+  });
+};
+
+/**
+ * 모든 상품의 피팅 영상 상태를 확인하는 훅
+ * 모든 products를 가져와서 각 product_id로 getFittingVideoStatus 호출
+ * status가 'completed'인 영상들만 반환
+ */
+export interface CompletedFittingVideo {
+  product_id: number;
+  product_name: string;
+  video_url: string;
+  status: 'completed';
+}
+
+export const useFittingVideos = () => {
+  return useQuery<CompletedFittingVideo[], Error>({
+    queryKey: ["fittingVideos"],
+    queryFn: async () => {
+      try {
+        // 1. 모든 상품 정보 가져오기
+        const productsResponse = await fetchProducts();
+        
+        // 2. 각 상품에 대해 영상 상태 확인
+        const videoStatusPromises = productsResponse.products.map(async (product) => {
+          try {
+            const statusResponse = await getFittingVideoStatus(product.product_id);
+            
+            // status가 'completed'이고 video_url이 있는 경우만 반환
+            if (statusResponse.status === 'completed' && statusResponse.video_url) {
+              return {
+                product_id: product.product_id,
+                product_name: product.name,
+                video_url: statusResponse.video_url,
+                status: 'completed' as const,
+              };
+            }
+            return null;
+          } catch (error) {
+            // 개별 상품의 영상 상태 조회 실패는 무시하고 null 반환
+            console.warn(`피팅 영상 상태 조회 실패 (product_id: ${product.product_id}):`, error);
+            return null;
+          }
+        });
+        
+        // 3. 모든 Promise 완료 후 null이 아닌 값들만 필터링
+        const results = await Promise.all(videoStatusPromises);
+        return results.filter((result): result is CompletedFittingVideo => result !== null);
+        
+      } catch (error) {
+        console.error("피팅 영상 목록 조회 실패:", error);
+        throw error;
+      }
+    },
+    staleTime: 1 * 60 * 1000, // 1분간 데이터를 신선하다고 간주
+    gcTime: 5 * 60 * 1000, // 5분간 캐시 유지
   });
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,31 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * 전화번호를 포맷팅합니다. (00000000000 -> 000-0000-0000)
+ */
+export function formatPhoneNumber(phoneNumber: string): string {
+  if (!phoneNumber) return "-";
+  
+  // 숫자만 추출
+  const numbers = phoneNumber.replace(/\D/g, "");
+  
+  // 11자리 숫자인 경우 (010-0000-0000 형식)
+  if (numbers.length === 11) {
+    return numbers.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3");
+  }
+  
+  // 10자리 숫자인 경우 (02-000-0000 형식)
+  if (numbers.length === 10) {
+    return numbers.replace(/(\d{2})(\d{4})(\d{4})/, "$1-$2-$3");
+  }
+  
+  // 9자리 숫자인 경우 (02-000-000 형식)
+  if (numbers.length === 9) {
+    return numbers.replace(/(\d{2})(\d{3})(\d{4})/, "$1-$2-$3");
+  }
+  
+  // 형식에 맞지 않는 경우 원본 반환
+  return phoneNumber;
+}


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---마이페이지 데이터 전달, 수정 기능 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

주요 변경사항

  - 개인정보 수정 기능: ProfileSection에서 이름, 사용자명, 이메일, 전화번호 편집 가능
  - 배송지 관리 기능: 주소 추가/수정/삭제 및 기본 배송지 설정
  - 가상 피팅 영상 표시: 완성된 피팅 영상 목록을 실제 API 데이터로 구현
  - 전화번호 포맷팅: 00000000000 → 000-0000-0000 형식으로 자동 변환

  구현 세부사항

  - PersonalInfoForm과 AddressManagement의 데이터가 ProfileSection에 실시간 반영
  - OrderContext의 BuyerInfo를 초기값으로 활용하되, 사용자 입력 데이터 우선 표시
  - 임시 배송지(BuyerInfo)를 편집 가능한 주소로 변환하는 기능
  - useFittingVideos 훅으로 완성된 가상 피팅 영상만 필터링하여 표시
  - Mock 데이터 제거하고 실제 상태 관리로 전환

  기술적 개선

  - useState 기반의 간단한 상태 관리 패턴 적용
  - ModalContext를 통한 폼-섹션 간 데이터 동기화
  - 전화번호 유틸리티 함수 추가 (formatPhoneNumber)

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #97 