### PR TITLE
[Feat] 로고가 Onboarding에서 멈추는게 아니라 작아지면서 헤더에 정착하도록 구현

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,236 +13,89 @@ interface HeaderProps {
   variant?: HeaderVariant;
   showSearch?: boolean;
   showUserActions?: boolean;
-  showNavigation?: boolean;
+  showCategoryMenu?: boolean;
 }
 
-const Header = memo(({
-  showSearch,
-  showUserActions,
-  showNavigation,
-}: HeaderProps) => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const {
-    inputValue,
-    setInputValue,
-    handleSearch,
-    selectedCategory,
-    setSelectedCategory,
-  } = useFilter();
-  const [scrollProgress, setScrollProgress] = useState(0);
-  const [lastScrollY, setLastScrollY] = useState(0);
-  const [isLogin, setIsLogin] = useState(false);
-  const isSticky = useHeaderSticky();
+const Header = memo(
+  ({ showSearch, showUserActions, showCategoryMenu }: HeaderProps) => {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const {
+      inputValue,
+      setInputValue,
+      handleSearch,
+      selectedCategory,
+      setSelectedCategory,
+    } = useFilter();
+    const [isLogin, setIsLogin] = useState(false);
+    const isSticky = useHeaderSticky();
 
-  // 로그인 상태 체크
-  useEffect(() => {
-    const checkLoginStatus = () => {
-      const token = localStorage.getItem("access_token");
-      setIsLogin(!!token);
-    };
+    // 로그인 상태 체크
+    useEffect(() => {
+      const checkLoginStatus = () => {
+        const token = localStorage.getItem("access_token");
+        setIsLogin(!!token);
+      };
 
-    // 컴포넌트 마운트 시 로그인 상태 체크
-    checkLoginStatus();
-
-    // 커스텀 이벤트 리스너 (같은 탭에서 로그인 상태 변경 감지)
-    const handleLoginStatusChange = () => {
+      // 컴포넌트 마운트 시 로그인 상태 체크
       checkLoginStatus();
-    };
 
-    window.addEventListener("loginStatusChange", handleLoginStatusChange);
+      // 커스텀 이벤트 리스너 (같은 탭에서 로그인 상태 변경 감지)
+      const handleLoginStatusChange = () => {
+        checkLoginStatus();
+      };
 
-    return () => {
-      window.removeEventListener("loginStatusChange", handleLoginStatusChange);
-    };
-  }, []);
-  const { cartData } = useCart();
-  const cartCount = cartData?.cart_product?.length || 0;
-  const { mutate: logoutMutation } = useLogoutMutation();
+      window.addEventListener("loginStatusChange", handleLoginStatusChange);
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentScrollY = window.scrollY;
-      const scrollDirection = currentScrollY > lastScrollY ? 1 : -1;
-      const isHomePage = location.pathname === "/";
+      return () => {
+        window.removeEventListener(
+          "loginStatusChange",
+          handleLoginStatusChange
+        );
+      };
+    }, []);
+    const { cartData } = useCart();
+    const cartCount = cartData?.cart_product?.length || 0;
+    const { mutate: logoutMutation } = useLogoutMutation();
 
-      if (isHomePage) {
-        // 비디오 섹션 내에서의 스크롤 진행도 계산
-        const maxScrollDistance = 100;
-        const rawProgress = Math.min(currentScrollY / maxScrollDistance, 1);
+    const handleCategoryClick = useCallback(
+      (category: string) => {
+        setSelectedCategory(category);
+      },
+      [setSelectedCategory]
+    );
 
-        let adjustedProgress;
-        if (scrollDirection > 0) {
-          adjustedProgress = Math.min(rawProgress * 1, 1);
-        } else {
-          adjustedProgress = Math.max(rawProgress * 1, 0);
-        }
+    const handleLogout = useCallback(() => {
+      logoutMutation();
+    }, [logoutMutation]);
 
-        setScrollProgress(adjustedProgress);
-      } else {
-        // 다른 페이지에서는 항상 메뉴 숨김
-        setScrollProgress(1);
-      }
+    // 카테고리 메뉴 아이템들
+    const categoryItems = ["모두 보기", "상의", "하의", "아우터"];
 
-      setLastScrollY(currentScrollY);
-    };
+    const isHomePage = location.pathname === "/";
 
-    // 스크롤 이벤트 리스너 등록
-    window.addEventListener("scroll", handleScroll, { passive: true });
-
-    // 초기 실행
-    handleScroll();
-
-    // 컴포넌트 언마운트 시 이벤트 리스너 제거
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, [lastScrollY, location.pathname]);
-
-  const handleLogoClick = useCallback(() => {
-    navigate("/");
-  }, [navigate]);
-
-  const handleCategoryClick = useCallback((category: string) => {
-    setSelectedCategory(category);
-  }, [setSelectedCategory]);
-
-  const handleLogout = useCallback(() => {
-    logoutMutation();
-  }, [logoutMutation]);
-
-  // 카테고리 메뉴 아이템들
-  const categoryItems = ["모두 보기", "상의", "하의", "아우터"];
-
-  const filterItems = ["보기", "2", "3", "필터"];
-
-  const isHomePage = location.pathname === "/";
-
-  return (
-    <header
-      className={`${
-        isHomePage && !isSticky
-          ? "relative bg-transparent"
-          : "fixed top-0 left-0 bg-transparent"
-      } w-full z-50 hover:bg-white/70 group transition-all duration-300`}
-    >
-      {/* Main Header */}
-      <div className="flex items-center justify-center py-5">
-        <div className="w-full max-w-[1440px] px-4 lg:px-8 xl:px-0">
-          <div className="flex items-center justify-between">
-            {/* Logo */}
-            <div className="flex items-center">
-              <div
-                className="w-[200px] md:w-[262px] h-[80px] md:h-[109px] flex items-center justify-center cursor-pointer"
-                onClick={handleLogoClick}
-              >
-                <span className="text-black text-[32px] md:text-[50px] leading-none font-butler">
-                  Morph
-                </span>
-              </div>
-            </div>
-
-            {/* Right Section */}
-            <div className="flex flex-col items-end gap-2 md:gap-4">
-              {/* Top Row - Search and User Actions */}
-              <div className="flex items-center gap-3 md:gap-5">
-                {/* Search */}
-                {showSearch && (
-                  <div className="w-[120px] md:w-[170px]">
-                    <input
-                      type="text"
-                      placeholder="검색"
-                      value={inputValue}
-                      onChange={(e) => setInputValue(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          handleSearch();
-                        }
-                      }}
-                      className="w-full bg-transparent border-b-1 border-black outline-none text-black text-[9px] md:text-[10px] font-inter leading-tight pb-1 placeholder-black focus:border-black"
-                    />
-                  </div>
-                )}
-
-                {/* User Actions */}
-                {showUserActions && (
-                  <div className="flex items-center gap-3 md:gap-5">
-                    {isLogin ? (
-                      <button
-                        type="button"
-                        className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
-                        onClick={handleLogout}
-                        aria-label="로그아웃"
-                      >
-                        로그아웃
-                      </button>
-                    ) : (
-                      <Suspense fallback={<span className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center">로그인</span>}>
-                        <LoginDialog>
-                          <button
-                            type="button"
-                            className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
-                            aria-label="로그인 창 열기"
-                          >
-                            로그인
-                          </button>
-                        </LoginDialog>
-                      </Suspense>
-                    )}
-                    <button
-                      type="button"
-                      className="text-black text-[9px] md:text-[10px] font-inter text-center w-[50px] md:w-[62px] h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
-                      onClick={() => {
-                        if (!isLogin) {
-                          alert("로그인이 필요합니다.");
-                          return;
-                        }
-                        navigate("/cart");
-                      }}
-                      aria-label={`장바구니 (상품 ${cartCount}개)`}
-                    >
-                      장바구니({cartCount})
-                    </button>
-                    <button
-                      type="button"
-                      className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
-                      onClick={() => {
-                        if (!isLogin) {
-                          alert("로그인이 필요합니다.");
-                          return;
-                        }
-                        navigate("/mypage");
-                      }}
-                      aria-label="마이페이지로 이동"
-                    >
-                      마이페이지
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* Navigation Menu */}
-          {showNavigation && (
-            <div
-              className="mt-[60px] md:mt-[80px] transition-all duration-300 ease-out overflow-hidden group-hover:!transform-none group-hover:!opacity-100 group-hover:!max-h-[100px]"
-              style={{
-                transform: `translateY(-${scrollProgress * 100}%)`,
-                opacity: 1 - scrollProgress,
-                maxHeight: `${(1 - scrollProgress) * 100}px`,
-                // marginTop: `${60 - scrollProgress * 30}px`,
-              }}
-            >
-              <div className="w-full max-w-[1200px] py-2">
-                <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 md:gap-0">
-                  {/* Category Menu */}
-                  <div className="flex flex-wrap items-center gap-2 md:gap-4">
+    return (
+      <header
+        className={`${
+          isHomePage && !isSticky
+            ? "relative bg-transparent"
+            : "fixed top-0 left-0 bg-transparent"
+        } w-full h-[149px] z-50 hover:bg-white/70 group transition-all duration-300`}
+      >
+        {/* Main Header */}
+        <div className="flex items-center h-[149px] justify-center py-5">
+          <div className="w-full max-w-[1440px] px-4 lg:px-8 xl:px-0">
+            <div className="flex items-center justify-between">
+              {/* Left Section - Category Menu 또는 Logo */}
+              <div className="flex items-center">
+                {showCategoryMenu ? (
+                  // Category Menu (Home 페이지)
+                  <div className="flex flex-wrap items-center gap-4 md:gap-6">
                     {categoryItems.map((item, index) => (
                       <span
                         key={index}
                         onClick={() => handleCategoryClick(item)}
-                        className={`text-black text-[9px] md:text-[10px] font-inter leading-4 cursor-pointer hover:opacity-70 transition-all whitespace-nowrap ${
+                        className={`text-black text-[10px] md:text-[12px] font-inter leading-4 cursor-pointer hover:opacity-70 transition-all whitespace-nowrap ${
                           selectedCategory === item
                             ? "font-bold"
                             : "font-normal"
@@ -252,27 +105,108 @@ const Header = memo(({
                       </span>
                     ))}
                   </div>
-
-                  {/* Filter Options */}
-                  <div className="flex items-center gap-1 md:gap-1">
-                    {filterItems.map((item, index) => (
-                      <span
-                        key={index}
-                        className="text-black text-[9px] md:text-[10px] font-inter leading-4 cursor-pointer hover:opacity-70 transition-opacity ml-2"
-                      >
-                        {item}
-                      </span>
-                    ))}
+                ) : (
+                  // Logo (다른 페이지들)
+                  <div className="cursor-pointer" onClick={() => navigate("/")}>
+                    <span className="text-black text-[60px] leading-none font-butler">
+                      Morph
+                    </span>
                   </div>
+                )}
+              </div>
+
+              {/* Right Section */}
+              <div className="flex flex-col items-end gap-2 md:gap-4">
+                {/* Top Row - Search and User Actions */}
+                <div className="flex items-center gap-3 md:gap-5">
+                  {/* Search */}
+                  {showSearch && (
+                    <div className="w-[120px] md:w-[170px]">
+                      <input
+                        type="text"
+                        placeholder="검색"
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            handleSearch();
+                          }
+                        }}
+                        className="w-full bg-transparent border-b-1 border-black outline-none text-black text-[9px] md:text-[10px] font-inter leading-tight pb-1 placeholder-black focus:border-black"
+                      />
+                    </div>
+                  )}
+
+                  {/* User Actions */}
+                  {showUserActions && (
+                    <div className="flex items-center gap-3 md:gap-5">
+                      {isLogin ? (
+                        <button
+                          type="button"
+                          className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
+                          onClick={handleLogout}
+                          aria-label="로그아웃"
+                        >
+                          로그아웃
+                        </button>
+                      ) : (
+                        <Suspense
+                          fallback={
+                            <span className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center">
+                              로그인
+                            </span>
+                          }
+                        >
+                          <LoginDialog>
+                            <button
+                              type="button"
+                              className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
+                              aria-label="로그인 창 열기"
+                            >
+                              로그인
+                            </button>
+                          </LoginDialog>
+                        </Suspense>
+                      )}
+                      <button
+                        type="button"
+                        className="text-black text-[9px] md:text-[10px] font-inter text-center w-[50px] md:w-[62px] h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
+                        onClick={() => {
+                          if (!isLogin) {
+                            alert("로그인이 필요합니다.");
+                            return;
+                          }
+                          navigate("/cart");
+                        }}
+                        aria-label={`장바구니 (상품 ${cartCount}개)`}
+                      >
+                        장바구니({cartCount})
+                      </button>
+                      <button
+                        type="button"
+                        className="text-black text-[9px] md:text-[10px] font-inter text-center w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
+                        onClick={() => {
+                          if (!isLogin) {
+                            alert("로그인이 필요합니다.");
+                            return;
+                          }
+                          navigate("/mypage");
+                        }}
+                        aria-label="마이페이지로 이동"
+                      >
+                        마이페이지
+                      </button>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
-          )}
+          </div>
         </div>
-      </div>
-    </header>
-  );
-});
+      </header>
+    );
+  }
+);
 
 Header.displayName = "Header";
 

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,6 +1,6 @@
 import Header from "./Header";
 import Footer from "./Footer";
-import React, { useEffect, useState, lazy, Suspense } from "react";
+import React, { useEffect, lazy, Suspense } from "react";
 import { useLocation } from "react-router-dom";
 import { useCart } from "@/contexts/CartContext";
 import { getLayoutConfig } from "@/config/layoutConfig";
@@ -17,9 +17,6 @@ interface LayoutProps {
 const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
   const location = useLocation();
   const { totalPrice: cartTotalPrice, directPurchaseProduct } = useCart();
-  const [onboardingTextStyle, setOnboardingTextStyle] = useState(
-    "opacity-0 translate-y-8"
-  );
 
   const layoutConfig = getLayoutConfig(location.pathname);
 
@@ -30,7 +27,7 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
       layoutConfig,
       showSearch: layoutConfig.showSearch,
       showUserActions: layoutConfig.showUserActions,
-      showNavigation: layoutConfig.showNavigation,
+      showCategoryMenu: layoutConfig.showCategoryMenu,
     });
   }
 
@@ -62,43 +59,10 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
 
   const isHomePage = location.pathname === "/";
 
-  // OnBoarding 텍스트 애니메이션을 위한 스크롤 이벤트 핸들러
+  // 페이지 네비게이션 시 스크롤을 맨 위로 이동
   useEffect(() => {
-    if (!isHomePage) return;
-
-    const handleScroll = () => {
-      const scrollY = window.scrollY;
-      const videoSectionHeight = 800; // VideoSection 높이
-      const animationStart = videoSectionHeight - 200; // OnBoarding 섹션 도달 200px 전부터 시작
-      const animationDuration = 400; // 애니메이션 지속 시간 (px)
-      const animationEnd = animationStart + animationDuration;
-
-      if (scrollY < animationStart) {
-        // 애니메이션 시작 전
-        setOnboardingTextStyle("opacity-0 translate-y-8");
-      } else if (scrollY >= animationStart && scrollY <= animationEnd) {
-        // 애니메이션 진행 중
-        const progress = (scrollY - animationStart) / animationDuration;
-        const opacity = Math.min(progress, 1);
-        const translateY = 8 - progress * 8; // 8px에서 0px로
-        setOnboardingTextStyle(
-          `opacity-${Math.round(opacity * 100)} translate-y-${Math.round(
-            translateY
-          )}`
-        );
-      } else {
-        // 애니메이션 완료
-        setOnboardingTextStyle("opacity-100 translate-y-0");
-      }
-    };
-
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll(); // 초기 상태 설정
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, [isHomePage]);
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -106,16 +70,16 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
         {isHomePage && (
           <>
             <VideoSection />
-            <OnBoarding textStyle={onboardingTextStyle} />
+            <OnBoarding />
             <MorphLogo />
           </>
         )}
         <Header
           showSearch={layoutConfig.showSearch}
           showUserActions={layoutConfig.showUserActions}
-          showNavigation={layoutConfig.showNavigation}
+          showCategoryMenu={layoutConfig.showCategoryMenu}
         />
-        <main className="mb-50">{children}</main>
+        <main className="mb-100">{children}</main>
         <Footer variant={finalFooterVariant} totalPrice={totalPrice} />
       </div>
     </Suspense>

--- a/src/components/sections/MorphLogo.tsx
+++ b/src/components/sections/MorphLogo.tsx
@@ -1,44 +1,65 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 const MorphLogo = () => {
-  const [logoPosition, setLogoPosition] = useState("fixed");
-  const releasePoint = 800;
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const shrinkStartPoint = 800; // 축소 시작 지점 (기존 release 지점)
+  const shrinkEndPoint = 2000; // 축소 완료 지점 (1000px 구간에서 축소)
+  const rafRef = useRef<number>(0);
 
-  // Morph logo scroll behavior
-  useEffect(() => {
-    const handleScroll = () => {
+  // Easing 함수 - ease-out 곡선 (부드러운 감속)
+  const easeOut = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+  // Morph logo scroll behavior - 부드러운 크기 축소 애니메이션
+  const handleScroll = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
       const scrollY = window.scrollY;
-      // VideoSection height is 800px, OnBoarding height is 1000px
-      // Logo should release when reaching onboarding section middle (800 + 500 = 1300px)
-      if (scrollY >= releasePoint) {
-        setLogoPosition("released");
-      } else {
-        if (logoPosition === "released") {
-          setLogoPosition("fixed");
-        }
-      }
-    };
 
+      if (scrollY < shrinkStartPoint) {
+        // 축소 시작 전: 큰 크기 유지
+        setScrollProgress(0);
+      } else if (scrollY >= shrinkStartPoint && scrollY <= shrinkEndPoint) {
+        // 축소 진행 중: 0에서 1까지의 진행도 with easing
+        const rawProgress =
+          (scrollY - shrinkStartPoint) / (shrinkEndPoint - shrinkStartPoint);
+        const easedProgress = easeOut(Math.min(rawProgress, 1));
+        setScrollProgress(easedProgress);
+      } else {
+        // 축소 완료: 헤더 크기로 고정
+        setScrollProgress(1);
+      }
+    });
+  }, [shrinkStartPoint, shrinkEndPoint]);
+
+  useEffect(() => {
     window.addEventListener("scroll", handleScroll, { passive: true });
     handleScroll(); // Initial position check
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
     };
-  }, [logoPosition]);
+  }, [handleScroll]);
+
+  // 크기 계산: 200px에서 75px로 축소 (easing 적용)
+  const logoSize = 200 - scrollProgress * 125; // 200px → 75px
+  const topPosition = 300 - scrollProgress * 235; // top-[300px] → top-[65px] (헤더 중앙)
 
   return (
     <div>
-      {/* Morph Logo with scroll-based positioning */}
+      {/* Morph Logo with scroll-based size transition */}
       <div
-        className={`
-          text-black text-[200px] h-[200px] font-butler z-[65] pointer-events-none
-          ${
-            logoPosition === "fixed"
-              ? "fixed top-[300px] left-1/2 transform -translate-x-1/2 -translate-y-1/2"
-              : "absolute top-[1000px] left-1/2 transform -translate-x-1/2"
-          }
-        `}
+        className="fixed left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-black font-butler z-[65] pointer-events-none transition-opacity duration-300"
+        style={{
+          fontSize: `${logoSize}px`,
+          height: `${logoSize}px`,
+          top: `${topPosition}px`,
+        }}
       >
         Morph
       </div>

--- a/src/components/sections/MorphLogo.tsx
+++ b/src/components/sections/MorphLogo.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 
 const MorphLogo = () => {
   const [scrollProgress, setScrollProgress] = useState(0);
-  const shrinkStartPoint = 800; // 축소 시작 지점 (기존 release 지점)
+  const shrinkStartPoint = 900; // 축소 시작 지점 (기존 release 지점)
   const shrinkEndPoint = 2000; // 축소 완료 지점 (1000px 구간에서 축소)
   const rafRef = useRef<number>(0);
 

--- a/src/components/sections/OnBoarding.tsx
+++ b/src/components/sections/OnBoarding.tsx
@@ -1,22 +1,90 @@
+import { useState, useEffect, useCallback, useRef } from "react";
 import onboardingBg from "@/assets/onboarding_bg.webp";
 
-const OnBoarding = ({ textStyle }: { textStyle: string }) => {
+const OnBoarding = () => {
+  const [textOpacity, setTextOpacity] = useState(0);
+  const [textTransformY, setTextTransformY] = useState(50);
+  const rafRef = useRef<number>(0);
+
+  // 스크롤 구간 설정
+  const videoSectionHeight = 800; // VideoSection 높이
+  const onboardingHeight = 1000; // OnBoarding 섹션 높이
+  const fadeInStart = videoSectionHeight - 100; // 페이드인 시작 (500px)
+  const fadeInEnd = videoSectionHeight + 100; // 페이드인 완료 (1000px)
+  const fadeOutStart = videoSectionHeight + 200; // 페이드아웃 시작 (1100px)
+  const fadeOutEnd = videoSectionHeight + onboardingHeight; // 페이드아웃 완료 (1600px)
+
+  // Easing 함수
+  const easeOut = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+  // 스크롤 핸들러
+  const handleScroll = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
+      const scrollY = window.scrollY;
+
+      if (scrollY < fadeInStart) {
+        // 애니메이션 시작 전 - 숨김 상태
+        setTextOpacity(0);
+        setTextTransformY(50);
+      } else if (scrollY >= fadeInStart && scrollY <= fadeInEnd) {
+        // 페이드인 구간 - 아래에서 위로 나타남
+        const progress = (scrollY - fadeInStart) / (fadeInEnd - fadeInStart);
+        const easedProgress = easeOut(progress);
+        setTextOpacity(easedProgress);
+        setTextTransformY(50 - easedProgress * 50); // 50px → 0px
+      } else if (scrollY > fadeInEnd && scrollY < fadeOutStart) {
+        // 완전히 표시된 상태
+        setTextOpacity(1);
+        setTextTransformY(0);
+      } else if (scrollY >= fadeOutStart && scrollY <= fadeOutEnd) {
+        // 페이드아웃 구간 - 위로 사라짐
+        const progress = (scrollY - fadeOutStart) / (fadeOutEnd - fadeOutStart);
+        const easedProgress = easeOut(progress);
+        setTextOpacity(1 - easedProgress);
+        setTextTransformY(-easedProgress * 50); // 0px → -50px
+      } else {
+        // 완전히 사라진 상태
+        setTextOpacity(0);
+        setTextTransformY(-50);
+      }
+    });
+  }, [fadeInStart, fadeInEnd, fadeOutStart, fadeOutEnd]);
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll(); // 초기 상태 설정
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [handleScroll]);
   return (
     <div className="relative z-[60] w-full h-[1000px] bg-white">
+      {/* 배경 이미지 */}
       <img
         src={onboardingBg}
         alt="onboarding"
         className="w-full h-full object-cover py-[100px] px-[50px]"
       />
-      <div className="absolute top-[100px] left-0 w-full h-full text-white text-center font-bold flex flex-col items-center justify-center">
-        <div
-          className={`text-[44px] mb-[20px] font-pretendard transition-all duration-300 ${textStyle}`}
-        >
+      {/* 텍스트 영역 - 동적 애니메이션 */}
+      <div
+        className="absolute top-[100px] left-0 w-full h-full text-white text-center font-bold flex flex-col items-center justify-center"
+        style={{
+          opacity: textOpacity,
+          transform: `translateY(${textTransformY}px)`,
+        }}
+      >
+        <div className="text-[44px] mb-[20px] font-pretendard">
           클릭 한 번으로 새로운 나를 발견하세요
         </div>
-        <div
-          className={`text-[28px] font-pretendard transition-all duration-300 ${textStyle}`}
-        >
+        <div className="text-[28px] font-pretendard">
           당신의 사진이 모든 옷의 피팅모델이 됩니다. AI가 완벽하게 합성해서 진짜
           입은 것처럼 보여드려요. <br />
           이제 다른 사람이 입은 옷 사진은 보지 마세요. 당신이 입은 모습만 보면

--- a/src/config/layoutConfig.ts
+++ b/src/config/layoutConfig.ts
@@ -6,7 +6,7 @@ interface LayoutConfig {
   footer: FooterVariant;
   showSearch?: boolean;
   showUserActions?: boolean;
-  showNavigation?: boolean;
+  showCategoryMenu?: boolean;
   requiresAuth?: boolean;
   title?: string;
 }
@@ -24,7 +24,7 @@ export const STATIC_LAYOUT_CONFIG: Record<string, LayoutConfig> = {
     footer: "default",
     showSearch: true,
     showUserActions: true,
-    showNavigation: true,
+    showCategoryMenu: true,
     title: "홈",
   },
   "/cart": {
@@ -32,7 +32,6 @@ export const STATIC_LAYOUT_CONFIG: Record<string, LayoutConfig> = {
     footer: "cart",
     showSearch: false,
     showUserActions: false,
-    showNavigation: false,
     title: "장바구니",
   },
   "/order": {
@@ -41,7 +40,6 @@ export const STATIC_LAYOUT_CONFIG: Record<string, LayoutConfig> = {
     showSearch: false,
     showUserActions: false,
     requiresAuth: true,
-    showNavigation: false,
     title: "주문 정보",
   },
   "/summary": {
@@ -50,7 +48,6 @@ export const STATIC_LAYOUT_CONFIG: Record<string, LayoutConfig> = {
     showSearch: false,
     showUserActions: false,
     requiresAuth: true,
-    showNavigation: false,
     title: "주문 요약",
   },
   "/history": {
@@ -59,7 +56,6 @@ export const STATIC_LAYOUT_CONFIG: Record<string, LayoutConfig> = {
     showSearch: false,
     showUserActions: false,
     requiresAuth: true,
-    showNavigation: false,
     title: "주문 내역",
   },
   "/mypage": {
@@ -68,7 +64,6 @@ export const STATIC_LAYOUT_CONFIG: Record<string, LayoutConfig> = {
     showSearch: false,
     showUserActions: true,
     requiresAuth: true,
-    showNavigation: false,
     title: "마이페이지",
   },
 } as const;
@@ -82,7 +77,6 @@ export const DYNAMIC_LAYOUT_CONFIG: RoutePattern[] = [
       footer: "default",
       showSearch: false,
       showUserActions: true,
-      showNavigation: false,
       title: "상품 상세",
     },
   },
@@ -94,7 +88,7 @@ export const DEFAULT_LAYOUT_CONFIG: LayoutConfig = {
   footer: "default",
   showSearch: true,
   showUserActions: true,
-  showNavigation: true,
+  showCategoryMenu: false,
   title: "Techeer Fashion",
 } as const;
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -146,11 +146,7 @@ const Home = () => {
   return (
     <div className="w-full bg-white relative">
       {/* Main Content */}
-      <div
-        className={`flex justify-center ${
-          isSticky ? "pt-[200px] md:pt-[260px]" : ""
-        }`}
-      >
+      <div className={`flex justify-center ${isSticky ? "pt-[149px]" : ""}`}>
         <div className="w-full max-w-[1201px] px-4 lg:px-8 xl:px-0">
           {/* Product Grid */}
           <div className="flex flex-col gap-[60px] md:gap-[80px]">
@@ -160,9 +156,11 @@ const Home = () => {
                 className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-[80px] justify-items-center"
               >
                 {row?.map((product) => (
-                  <Suspense 
+                  <Suspense
                     key={product.product_id}
-                    fallback={<div className="w-[240px] h-[360px] bg-gray-100 animate-pulse rounded-lg"></div>}
+                    fallback={
+                      <div className="w-[240px] h-[360px] bg-gray-100 animate-pulse rounded-lg"></div>
+                    }
                   >
                     <ProductCard
                       variant="default"


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

--- [Feat] 로고가 Onboarding에서 멈추는게 아니라 작아지면서 헤더에 정착하도록 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

---로고 및 헤더 UX 개선

  주요 변경사항

  🎯 MorphLogo 스크롤 애니메이션 개선

  - 부드러운 크기 축소: 800px~2000px 구간에서 200px → 75px로 점진적 축소
  - 헤더 중앙 안착: 스크롤 완료 시 헤더 중앙에 자연스럽게 위치
  - 성능 최적화: requestAnimationFrame + easeOut 함수로 60fps 부드러운 애니메이션

  🧭 헤더 레이아웃 개선

  - 페이지별 조건부 렌더링:
    - Home: Category Menu (왼쪽) + 검색/사용자액션 (오른쪽)
    - 기타 페이지: 일반 로고 (왼쪽) + 검색/사용자액션 (오른쪽)
  - LayoutConfig 확장: showCategoryMenu 설정 추가로 페이지별 커스터마이징

  📜 OnBoarding 텍스트 애니메이션 강화

  - 2단계 스크롤 애니메이션:
    - 페이드인 (700px~900px): 아래에서 위로 나타남
    - 페이드아웃 (1100px~1800px): 중앙에서 위로 사라짐
  - 자체 스크롤 핸들링: Layout 의존성 제거로 독립적 동작

  🔄 네비게이션 UX 개선

  - 스크롤 위치 초기화: 모든 페이지 이동 시 자동으로 맨 위로 스크롤

  기술적 개선

  - 불필요한 스크롤 이벤트 리스너 제거
  - useCallback + requestAnimationFrame으로 성능 최적화
  - 코드 중복 제거 및 관심사 분리

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #103 