### PR TITLE
[Feat] 카테고리 조회 API 연동, 필터링 구현

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -24,8 +24,8 @@ export const fetchProductDetail = async (
 };
 
 // 카테고리별 상품 조회
-export const fetchCategories = async (): Promise<CategoryResponse> => {
-  const response = await axiosInstance.get<CategoryResponse>("api/v1/categories/");
+export const fetchCategoryProducts = async (categoryId: number): Promise<CategoryResponse> => {
+  const response = await axiosInstance.get<CategoryResponse>(`api/v1/categories/${categoryId}`);
   return response.data;
 };
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -32,8 +32,8 @@ const Header = memo(
       inputValue,
       setInputValue,
       handleSearch,
-      selectedCategory,
-      setSelectedCategory,
+      selectedCategoryId,
+      setSelectedCategoryId,
     } = useFilter();
     const [isLogin, setIsLogin] = useState(false);
     const [isSearchExpanded, setIsSearchExpanded] = useState(false);
@@ -68,10 +68,32 @@ const Header = memo(
     const cartCount = cartData?.cart_product?.length || 0;
 
     const handleCategoryClick = useCallback(
-      (category: string) => {
-        setSelectedCategory(category);
+      (categoryName: string) => {
+        let categoryId: number | null = null;
+        
+        switch (categoryName) {
+          case "상의":
+            categoryId = 1;
+            break;
+          case "하의":
+            categoryId = 2;
+            break;
+          case "아우터":
+            categoryId = 3;
+            break;
+          case "모두 보기":
+          default:
+            categoryId = null;
+            break;
+        }
+
+        setSelectedCategoryId(categoryId);
+        // 홈페이지가 아닌 경우 홈페이지로 이동
+        if (location.pathname !== "/") {
+          navigate("/");
+        }
       },
-      [setSelectedCategory]
+      [setSelectedCategoryId, location.pathname, navigate]
     );
 
     const toggleSearch = useCallback(() => {
@@ -120,17 +142,25 @@ const Header = memo(
                 {showCategoryMenu ? (
                   // Category Menu (Home 페이지)
                   <div className="flex flex-wrap items-center gap-4 md:gap-6">
-                    {categoryItems.map((item, index) => (
-                      <span
-                        key={index}
-                        onClick={() => handleCategoryClick(item)}
-                        className={`text-black text-[15px] font-inter leading-4 cursor-pointer hover:opacity-70 transition-all whitespace-nowrap ${
-                          selectedCategory === item ? "font-bold" : "font-light"
-                        }`}
-                      >
-                        {item}
-                      </span>
-                    ))}
+                    {categoryItems.map((item, index) => {
+                      const isSelected = 
+                        (item === "모두 보기" && selectedCategoryId === null) ||
+                        (item === "상의" && selectedCategoryId === 1) ||
+                        (item === "하의" && selectedCategoryId === 2) ||
+                        (item === "아우터" && selectedCategoryId === 3);
+
+                      return (
+                        <span
+                          key={index}
+                          onClick={() => handleCategoryClick(item)}
+                          className={`text-black text-[15px] font-inter leading-4 cursor-pointer hover:opacity-70 transition-all whitespace-nowrap ${
+                            isSelected ? "font-bold" : "font-light"
+                          }`}
+                        >
+                          {item}
+                        </span>
+                      );
+                    })}
                   </div>
                 ) : (
                   // Logo (다른 페이지들)

--- a/src/contexts/FilterContext.tsx
+++ b/src/contexts/FilterContext.tsx
@@ -3,10 +3,10 @@ import type { ReactNode } from 'react';
 
 interface FilterContextType {
   searchQuery: string;
-  selectedCategory: string;
+  selectedCategoryId: number | null;
   inputValue: string;
   setInputValue: (value: string) => void;
-  setSelectedCategory: (category: string) => void;
+  setSelectedCategoryId: (categoryId: number | null) => void;
   handleSearch: () => void;
 }
 
@@ -26,7 +26,7 @@ interface FilterProviderProps {
 
 export const FilterProvider = ({ children }: FilterProviderProps) => {
   const [searchQuery, setSearchQuery] = useState<string>('');
-  const [selectedCategory, setSelectedCategory] = useState<string>('모두 보기');
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null); // null = 모두 보기
   const [inputValue, setInputValue] = useState<string>('');
 
   const handleSearch = useCallback(() => {
@@ -35,12 +35,12 @@ export const FilterProvider = ({ children }: FilterProviderProps) => {
 
   const value = useMemo(() => ({
     searchQuery,
-    selectedCategory,
+    selectedCategoryId,
     inputValue,
     setInputValue,
-    setSelectedCategory,
+    setSelectedCategoryId,
     handleSearch,
-  }), [searchQuery, selectedCategory, inputValue, setInputValue, setSelectedCategory, handleSearch]);
+  }), [searchQuery, selectedCategoryId, inputValue, setInputValue, setSelectedCategoryId, handleSearch]);
 
   return (
     <FilterContext.Provider value={value}>

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import {
   fetchProducts,
   fetchProductDetail,
-  fetchCategories,
+  fetchCategoryProducts,
   fetchProductFittingImage,
   type ProductFittingImageResponse,
 } from "../api/products";
@@ -31,12 +31,12 @@ export const useProductDetailQuery = (productId: number) => {
 };
 
 // 카테고리 쿼리
-export const useCategoriesQuery = () => {
+export const useCategoriesQuery = (categoryId: number) => {
   return useQuery({
-    queryKey: ["categories"],
-    queryFn: fetchCategories,
-    staleTime: 30 * 60 * 1000, // 30분 (카테고리는 자주 변경되지 않음)
-    gcTime: 60 * 60 * 1000, // 1시간
+    queryKey: ["categories", categoryId],
+    queryFn: () => fetchCategoryProducts(categoryId),
+    staleTime: 5 * 60 * 1000, // 5분 (카테고리는 자주 변경되지 않음)
+    gcTime: 10 * 60 * 1000, // 10분
   });
 };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,7 +9,8 @@ import {
   useProductsQuery,
   useAllProductsFittingImages,
 } from "@/hooks/useProducts";
-import { fetchProductFittingImage, type ProductFittingImageResponse } from "@/api/products";
+import { fetchProductFittingImage, fetchCategoryProducts, type ProductFittingImageResponse } from "@/api/products";
+import type { Product, CategoryResponse } from "@/types/product";
 import { useFittingResultsPollingMutation } from "@/hooks/useFittings";
 import { getUserImages } from "@/api/users";
 import { useHeaderSticky } from "@/hooks/useHeaderSticky";
@@ -18,7 +19,7 @@ import { MorphSpinner } from "@/components/ui/morph-spinner";
 
 const Home = () => {
   const navigate = useNavigate();
-  const { searchQuery } = useFilter();
+  const { searchQuery, selectedCategoryId } = useFilter();
   const {
     showFitting,
     setShowFitting,
@@ -34,6 +35,7 @@ const Home = () => {
   } = useFittingContext();
   const [buttonText, setButtonText] = useState<string>("피팅하기");
   const [viewedProducts, setViewedProducts] = useState<string[]>([]);
+  const [categoryProducts, setCategoryProducts] = useState<CategoryResponse | null>(null);
   const { openModal } = useModal();
   const isSticky = useHeaderSticky();
   const { data: products } = useProductsQuery();
@@ -66,6 +68,26 @@ const Home = () => {
     setCurrentUserImageId(null);
     resetFittingResults();
   }, []); // 컴포넌트 마운트 시에만 실행
+
+  // 카테고리별 상품 조회
+  useEffect(() => {
+    const loadCategoryProducts = async () => {
+      if (selectedCategoryId === null) {
+        setCategoryProducts(null);
+        return;
+      }
+
+      try {
+        const data = await fetchCategoryProducts(selectedCategoryId);
+        setCategoryProducts(data);
+      } catch (error) {
+        console.error("카테고리별 상품 조회 실패:", error);
+        setCategoryProducts(null);
+      }
+    };
+
+    loadCategoryProducts();
+  }, [selectedCategoryId]);
 
   // 조회한 상품 목록을 localStorage에 저장
   const saveViewedProducts = (products: string[]) => {
@@ -246,29 +268,43 @@ const Home = () => {
     }
   };
 
-  // Using dummy data instead of API
   // 검색어와 카테고리로 상품 필터링
-  const filteredProducts = useMemo(
-    () =>
-      products?.products?.filter((product) => {
-        const matchesSearch = product.name
-          .toLowerCase()
-          .includes(searchQuery.toLowerCase());
+  const filteredProducts = useMemo(() => {
+    let sourceProducts: Product[] = [];
+    
+    if (selectedCategoryId !== null && categoryProducts) {
+      // 카테고리 상품의 경우 속성명을 통일 (id -> product_id)
+      sourceProducts = categoryProducts.data?.products?.map((product: any) => ({
+        ...product,
+        product_id: product.id || product.product_id, // id를 product_id로 매핑
+      })) || [];
+    } else {
+      sourceProducts = products?.products || [];
+    }
 
-        // 카테고리 매칭: category_id를 통해 카테고리 이름 찾기
-        // const productCategory = categories?.find(cat => cat.categoryName === product.category_name)?.name;
-        // const matchesCategory = selectedCategory === "모두 보기" || productCategory === selectedCategory;
+    const filtered = sourceProducts.filter((product: Product) => {
+      if (!product || !product.name || !product.product_id) return false;
+      
+      const matchesSearch = product.name
+        .toLowerCase()
+        .includes(searchQuery.toLowerCase());
 
-        return matchesSearch;
-      }),
-    [products?.products, searchQuery]
-  );
+      return matchesSearch;
+    });
+
+    return filtered;
+  }, [products?.products, categoryProducts, searchQuery, selectedCategoryId]);
 
   // 필터링된 상품을 4개씩 그룹화하여 행으로 나눔
   const productRows = useMemo(() => {
+    if (!filteredProducts || filteredProducts.length === 0) return [];
+    
     const rows = [];
-    for (let i = 0; i < (filteredProducts?.length ?? 0); i += 4) {
-      rows.push(filteredProducts?.slice(i, i + 4));
+    for (let i = 0; i < filteredProducts.length; i += 4) {
+      const row = filteredProducts.slice(i, i + 4).filter(product => product && product.product_id);
+      if (row.length > 0) {
+        rows.push(row);
+      }
     }
     return rows;
   }, [filteredProducts]);
@@ -299,34 +335,38 @@ const Home = () => {
                 key={rowIndex}
                 className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-[80px] justify-items-center"
               >
-                {row?.map((product) => (
-                  <Suspense
-                    key={product.product_id}
-                    fallback={
-                      <div className="w-[240px] h-[360px] bg-gray-100 animate-pulse rounded-lg"></div>
-                    }
-                  >
-                    <ProductCard
-                      variant={
-                        viewedProducts.includes(product.product_id.toString())
-                          ? "viewed"
-                          : "default"
+                {row?.map((product) => {
+                  if (!product || !product.product_id) return null;
+                  
+                  return (
+                    <Suspense
+                      key={product.product_id}
+                      fallback={
+                        <div className="w-[240px] h-[360px] bg-gray-100 animate-pulse rounded-lg"></div>
                       }
-                      product={{
-                        ...product,
-                        // 피팅 모드일 때 피팅 이미지를 사용, 아니면 원본 이미지 사용
-                        image:
-                          showFitting &&
-                          fittingResults[product.product_id]?.fitting_image
-                            ? fittingResults[product.product_id].fitting_image
-                            : product.image,
-                      }}
-                      onProductClick={() =>
-                        handleProductClick(product.product_id)
-                      }
-                    />
-                  </Suspense>
-                ))}
+                    >
+                      <ProductCard
+                        variant={
+                          viewedProducts.includes(product.product_id.toString())
+                            ? "viewed"
+                            : "default"
+                        }
+                        product={{
+                          ...product,
+                          // 피팅 모드일 때 피팅 이미지를 사용, 아니면 원본 이미지 사용
+                          image:
+                            showFitting &&
+                            fittingResults[product.product_id]?.fitting_image
+                              ? fittingResults[product.product_id].fitting_image
+                              : product.image,
+                        }}
+                        onProductClick={() =>
+                          handleProductClick(product.product_id)
+                        }
+                      />
+                    </Suspense>
+                  );
+                })}
               </div>
             ))}
           </div>

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,7 +1,0 @@
-export type Category = {
-  id: number;
-  name: string;
-  created_at: string;
-  updated_at: string;
-  is_deleted: boolean;
-};

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -23,6 +23,21 @@ export interface ProductListResponse {
   products: Product[];
 }
 
+export type Category = {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  is_deleted: boolean;
+};
+
+
 export interface CategoryResponse {
-  [categoryName: string]: Product[];
+  status: string;
+  message: string;
+  data: {
+    id: number;
+    name: string;
+    products: Product[];
+  }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---카테고리 조회 API 연동, 필터링 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

주요 변경사항

  - FilterContext 개선: selectedCategory 문자열 → selectedCategoryId (number | null)로 변경
  - Header 컴포넌트: 카테고리 클릭 시 ID 매핑 (상의: 1, 하의: 2, 아우터: 3, 모두 보기: null)
  - Home 페이지: fetchCategoryProducts API 연동으로 카테고리별 상품 필터링

  기능

  - 헤더에서 카테고리 선택 시 해당 카테고리 상품만 표시
  - "모두 보기" 선택 시 전체 상품 표시
  - 검색 기능과 카테고리 필터링 동시 지원

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #127 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카테고리별 상품 조회 및 필터링 기능이 추가되었습니다. 이제 카테고리를 선택하면 해당 카테고리의 상품만 볼 수 있습니다.

* **버그 수정**
  * 상품 목록 렌더링 시 유효하지 않은 상품 데이터가 있을 경우 표시되지 않도록 개선되었습니다.

* **리팩터링**
  * 카테고리 선택 로직이 문자열 기반에서 숫자 ID 기반으로 변경되어 일관성과 성능이 향상되었습니다.
  * 카테고리 관련 타입과 응답 구조가 명확하게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->