### PR TITLE
[Feat] 스크롤에 따른 온보딩 섹션 애니메이션 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     
     <!-- Font preloading for critical fonts -->
-    <link rel="preload" href="./src/assets/fonts/Pretendard-ExtraLight.subset.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="./src/assets/fonts/Pretendard-ExtraLight.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="./src/assets/fonts/Butler-Black.woff2" as="font" type="font/woff2" crossorigin />
     
     <!-- Critical CSS inline -->

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,6 +1,13 @@
 import Header from "./Header";
 import Footer from "./Footer";
-import React, { useEffect, lazy, Suspense } from "react";
+import React, {
+  useEffect,
+  lazy,
+  Suspense,
+  useState,
+  useCallback,
+  useRef,
+} from "react";
 import { useLocation } from "react-router-dom";
 import { useCart } from "@/contexts/CartContext";
 import { useOrder } from "@/contexts/OrderContext";
@@ -19,6 +26,10 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
   const location = useLocation();
   const { totalPrice: cartTotalPrice, directPurchaseProduct } = useCart();
   const { getLatestOrder } = useOrder();
+  const [onboardingScale, setOnboardingScale] = useState(1);
+  const [onboardingTranslateY, setOnboardingTranslateY] = useState(100);
+  const [onboardingOpacity, setOnboardingOpacity] = useState(1);
+  const rafRef = useRef<number>(0);
 
   const layoutConfig = getLayoutConfig(location.pathname);
 
@@ -72,6 +83,86 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
 
   const isHomePage = location.pathname === "/";
 
+  // Easing 함수
+  const easeOut = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+  // 온보딩 섹션 애니메이션 핸들러
+  const handleOnboardingScroll = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
+      const scrollY = window.scrollY;
+
+      // 애니메이션 구간 정의
+      const videoSectionHeight = 800;
+      const onboardingHeight = 1000;
+      const onboardingTopMargin = 100; // pt-[100px]
+
+      // 온보딩 섹션의 실제 시작점과 끝점 (마진 고려)
+      const onboardingStart = videoSectionHeight + onboardingTopMargin; // 900px
+      const onboardingEnd = videoSectionHeight + onboardingHeight; // 1800px
+
+      // 1. 입장 애니메이션: VideoSection 후반부에서 온보딩이 밑에서 올라옴
+      const entranceStart = 100; // 600px (VideoSection 후반)
+      const entranceEnd = onboardingStart; // 900px (온보딩 시작)
+
+      // 2. 퇴장 애니메이션: 온보딩 끝 200px 전부터 축소
+      const exitStart = onboardingEnd - 300; // 1500px
+      const exitEnd = onboardingEnd; // 1800px
+
+      if (scrollY >= entranceStart && scrollY <= entranceEnd) {
+        // 입장 애니메이션: 600px~900px 구간에서 밑에서 위로 올라옴
+        const progress =
+          (scrollY - entranceStart) / (entranceEnd - entranceStart);
+        const easedProgress = easeOut(progress);
+        setOnboardingTranslateY(150 - easedProgress * 150); // 100px → 0px
+        setOnboardingOpacity(0 + easedProgress * 1);
+        setOnboardingScale(1); // 스케일은 정상 유지
+      } else if (scrollY > entranceEnd && scrollY < exitStart) {
+        // 정상 상태: 900px~1600px 구간에서 원래 위치 유지
+        setOnboardingTranslateY(0);
+        setOnboardingScale(1);
+        setOnboardingOpacity(1);
+      } else if (scrollY >= exitStart && scrollY <= exitEnd) {
+        // 퇴장 애니메이션: 1600px~1800px 구간에서 축소 + 흐려짐
+        const progress = (scrollY - exitStart) / (exitEnd - exitStart);
+        const easedProgress = easeOut(progress);
+        setOnboardingTranslateY(0); // 위치는 고정
+        setOnboardingScale(1 - easedProgress * 0.3); // 1.0 → 0.7
+        setOnboardingOpacity(1 - easedProgress); // 1.0 → 0.0 (완전히 투명)
+      } else if (scrollY > exitEnd) {
+        // 완전히 사라진 상태
+        setOnboardingTranslateY(0);
+        setOnboardingScale(0.7);
+        setOnboardingOpacity(0);
+      } else {
+        // 초기 상태 (스크롤 600px 이전) - 온보딩 숨김
+        setOnboardingTranslateY(150);
+        setOnboardingScale(1);
+        setOnboardingOpacity(0);
+      }
+    });
+  }, []);
+
+  // 홈페이지에서만 스크롤 리스너 등록
+  useEffect(() => {
+    if (isHomePage) {
+      window.addEventListener("scroll", handleOnboardingScroll, {
+        passive: true,
+      });
+      handleOnboardingScroll(); // 초기 상태 설정
+
+      return () => {
+        window.removeEventListener("scroll", handleOnboardingScroll);
+        if (rafRef.current) {
+          cancelAnimationFrame(rafRef.current);
+        }
+      };
+    }
+  }, [isHomePage, handleOnboardingScroll]);
+
   // 페이지 네비게이션 시 스크롤을 맨 위로 이동
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -81,11 +172,18 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
     <Suspense fallback={<div>Loading...</div>}>
       <div>
         {isHomePage && (
-          <>
+          <div className="relative z-[60]">
             <VideoSection />
-            <OnBoarding />
+            {/* 온보딩 섹션 공간을 항상 확보하는 래퍼 */}
+            <div className="relative h-[1000px] bg-white">
+              <OnBoarding
+                scale={onboardingScale}
+                translateY={onboardingTranslateY}
+                opacity={onboardingOpacity}
+              />
+            </div>
             <MorphLogo />
-          </>
+          </div>
         )}
         <Header
           showSearch={layoutConfig.showSearch}

--- a/src/components/sections/OnBoarding.tsx
+++ b/src/components/sections/OnBoarding.tsx
@@ -1,7 +1,17 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import onboardingBg from "@/assets/onboarding_bg.webp";
 
-const OnBoarding = () => {
+interface OnBoardingProps {
+  scale?: number;
+  translateY?: number;
+  opacity?: number;
+}
+
+const OnBoarding = ({
+  scale = 1,
+  translateY = 0,
+  opacity = 1,
+}: OnBoardingProps) => {
   const [textOpacity, setTextOpacity] = useState(0);
   const [textTransformY, setTextTransformY] = useState(50);
   const rafRef = useRef<number>(0);
@@ -26,6 +36,7 @@ const OnBoarding = () => {
     rafRef.current = requestAnimationFrame(() => {
       const scrollY = window.scrollY;
 
+      // 기존 텍스트 애니메이션
       if (scrollY < fadeInStart) {
         // 애니메이션 시작 전 - 숨김 상태
         setTextOpacity(0);
@@ -66,12 +77,21 @@ const OnBoarding = () => {
     };
   }, [handleScroll]);
   return (
-    <div className="relative z-[60] w-full h-[1000px] bg-white">
-      {/* 배경 이미지 */}
+    <div
+      className="relative z-[60] w-full h-[1000px] bg-white overflow-hidden transition-all duration-300 ease-out"
+      style={{
+        transform: `translateY(${translateY}px)`,
+      }}
+    >
+      {/* 배경 이미지 - 스케일 애니메이션 적용 */}
       <img
         src={onboardingBg}
         alt="onboarding"
-        className="w-full h-full object-cover pt-[100px] pb-[50px]"
+        className="w-full h-full object-cover pt-[100px] pb-[50px] transition-transform duration-300 ease-out"
+        style={{
+          transform: `scale(${scale})`,
+          opacity: opacity,
+        }}
       />
       {/* 텍스트 영역 - 동적 애니메이션 */}
       <div


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---스크롤에 따른 온보딩 섹션 애니메이션 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

 - 스크롤에 따라 온보딩 섹션이 부드럽게 나타나고 사라지는 애니메이션 추가
  - 입장: VideoSection 밑에서 위로 올라오며 페이드인
  - 유지: 온보딩 구간에서 정상 표시
  - 퇴장: 온보딩 끝부분에서 스케일 축소 및 페이드아웃
  - 피팅하기 플로팅 버튼이 온보딩 섹션에 의해 적절히 가려지도록 z-index 및 레이아웃 개선

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 홈페이지 온보딩 섹션에 스크롤 기반 애니메이션이 추가되어 스크롤 위치에 따라 온보딩이 자연스럽게 나타나고 사라집니다.

* **스타일**
  * 온보딩 컴포넌트가 외부에서 애니메이션 스타일(크기, 투명도, 위치) 제어를 지원합니다.
  * "Pretendard-ExtraLight" 폰트 프리로드 리소스가 전체 폰트 파일로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->