### PR TITLE
[Fix] 피팅하기 재시도 로직 수정

### DIFF
--- a/src/hooks/useFittings.ts
+++ b/src/hooks/useFittings.ts
@@ -65,20 +65,12 @@ export const useGenerateFittingVideoMutation = () => {
 };
 
 /**
- * 새로운 피팅 시작 + 폴링 뮤테이션 훅 
- * startFittingDetail 호출 후 개별 상품별로 피팅 결과 폴링
- * userImageId에 대한 모든 상품의 피팅 결과를 개별적으로 폴링
+ * 새로운 피팅 시작 뮤테이션 훅
+ * startFittingDetail을 한 번만 호출하여 비용 중복 방지
  */
-export const useFittingResultsPollingMutation = () => {
-  const queryClient = useQueryClient();
-  
-  return useMutation<{ userImageId: number; results: Record<number, ProductFittingImageResponse> }, Error, { 
-    imageFile: File;
-    productIds: number[];
-    onProgress?: (completedCount: number, totalCount: number) => void; 
-  }>({
-    mutationFn: async ({ imageFile, productIds, onProgress }) => {
-      // 1. 먼저 새로운 피팅 시작
+export const useStartFittingMutation = () => {
+  return useMutation<{ user_image_id: number }, Error, File>({
+    mutationFn: async (imageFile: File) => {
       console.log("새로운 피팅 시작 - startFittingDetail 호출");
       const fittingResponse = await startFittingDetail(imageFile);
       
@@ -86,13 +78,34 @@ export const useFittingResultsPollingMutation = () => {
         throw new Error("피팅 시작 실패: user_image_id가 없습니다");
       }
       
-      const userImageId = fittingResponse.user_image_id;
-      console.log("새 피팅 시작 - user_image_id:", userImageId);
-      
+      console.log("새 피팅 시작 - user_image_id:", fittingResponse.user_image_id);
+      return fittingResponse;
+    },
+    retry: false, // 🚨 중요: 재시도 금지 - 비용 중복 방지
+    onError: (error) => {
+      console.error("피팅 시작 실패:", error);
+    },
+  });
+};
+
+/**
+ * 피팅 결과 폴링 뮤테이션 훅 (재시도 안전)
+ * userImageId에 대한 모든 상품의 피팅 결과를 개별적으로 폴링
+ * startFittingDetail 호출 없이 결과만 확인하므로 재시도 시 비용 발생 없음
+ */
+export const useFittingResultsPollingMutation = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation<{ userImageId: number; results: Record<number, ProductFittingImageResponse> }, Error, { 
+    userImageId: number;
+    productIds: number[];
+    onProgress?: (completedCount: number, totalCount: number) => void; 
+  }>({
+    mutationFn: async ({ userImageId, productIds, onProgress }) => {
       const results: Record<number, ProductFittingImageResponse> = {};
       let completedCount = 0;
       
-      // 2. 최소 3초 대기와 피팅 결과 폴링을 병렬로 실행
+      // 최소 3초 대기와 피팅 결과 폴링을 병렬로 실행
       const [fittingResults] = await Promise.all([
         (async () => {
           // 각 상품별로 피팅 결과 확인

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -88,6 +88,7 @@ export const useAllProductsFittingImages = (
         ...prev, 
         [productId]: error?.response?.data?.error || 'No existing fitting result' 
       }));
+      setCompletedProductIds(prev => new Set(prev).add(productId)); // 에러도 완료로 처리
       setLoadingStates(prev => ({ ...prev, [productId]: false }));
     }
   }, [userImageId, fittingMutation, completedProductIds]);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,9 +9,13 @@ import {
   useProductsQuery,
   useAllProductsFittingImages,
 } from "@/hooks/useProducts";
-import { fetchProductFittingImage, fetchCategoryProducts, type ProductFittingImageResponse } from "@/api/products";
+import {
+  fetchProductFittingImage,
+  fetchCategoryProducts,
+  type ProductFittingImageResponse,
+} from "@/api/products";
 import type { Product, CategoryResponse } from "@/types/product";
-import { useFittingResultsPollingMutation } from "@/hooks/useFittings";
+import { useStartFittingMutation, useFittingResultsPollingMutation } from "@/hooks/useFittings";
 import { getUserImages } from "@/api/users";
 import { useHeaderSticky } from "@/hooks/useHeaderSticky";
 import { useModal } from "@/contexts/ModalContext";
@@ -35,19 +39,22 @@ const Home = () => {
   } = useFittingContext();
   const [buttonText, setButtonText] = useState<string>("피팅하기");
   const [viewedProducts, setViewedProducts] = useState<string[]>([]);
-  const [categoryProducts, setCategoryProducts] = useState<CategoryResponse | null>(null);
+  const [categoryProducts, setCategoryProducts] =
+    useState<CategoryResponse | null>(null);
   const { openModal } = useModal();
   const isSticky = useHeaderSticky();
   const { data: products } = useProductsQuery();
 
+  const startFittingMutation = useStartFittingMutation();
   const fittingPollingMutation = useFittingResultsPollingMutation();
 
   // 피팅 모드일 때 개별 상품별 피팅 이미지 폴링
-  const { fittingResults, resetFittingResults, setManualFittingResults } = useAllProductsFittingImages(
-    products?.products?.map((p) => p.product_id) || [],
-    currentUserImageId,
-    showFitting && currentUserImageId !== null
-  );
+  const { fittingResults, resetFittingResults, setManualFittingResults } =
+    useAllProductsFittingImages(
+      products?.products?.map((p) => p.product_id) || [],
+      currentUserImageId,
+      showFitting && currentUserImageId !== null
+    );
 
   // localStorage에서 조회한 상품 목록 로드
   useEffect(() => {
@@ -107,7 +114,7 @@ const Home = () => {
   };
 
   const handleFittingClick = () => {
-    if (isFittingLoading || fittingPollingMutation.isPending) return;
+    if (isFittingLoading || startFittingMutation.isPending || fittingPollingMutation.isPending) return;
 
     openModal(
       "photoSelection",
@@ -119,14 +126,16 @@ const Home = () => {
     );
   };
 
-  const handlePhotoSelection = async (selectedPhoto: File | string | number) => {
+  const handlePhotoSelection = async (
+    selectedPhoto: File | string | number
+  ) => {
     console.log("선택된 사진:", selectedPhoto);
 
     // 선택된 이미지를 컨텍스트에 저장
     if (selectedPhoto instanceof File) {
       setLastSelectedImage(selectedPhoto);
       setLastSelectedUserImageId(null); // File 선택 시 user_image_id 초기화
-    } else if (typeof selectedPhoto === 'number') {
+    } else if (typeof selectedPhoto === "number") {
       setLastSelectedUserImageId(selectedPhoto);
       setLastSelectedImage(null); // user_image_id 선택 시 File 초기화
     }
@@ -144,25 +153,31 @@ const Home = () => {
 
     try {
       // 선택된 사진이 숫자(user_image_id)인 경우 - 기존 피팅 결과 불러오기
-      if (typeof selectedPhoto === 'number') {
+      if (typeof selectedPhoto === "number") {
         console.log("기존 피팅 결과 불러오기 - user_image_id:", selectedPhoto);
-        
+
         if (products?.products) {
           // 기존 피팅 결과 리셋
           resetFittingResults();
-          
+
           // 상태 업데이트
           setCurrentUserImageId(selectedPhoto);
           setShowFitting(true);
-          
+
           console.log("기존 피팅 결과 직접 조회 시작");
-          
+
           // 모든 상품에 대해 기존 피팅 결과를 병렬로 조회
           const existingResults = await Promise.allSettled(
             products.products.map(async (product) => {
               try {
-                const result = await fetchProductFittingImage(product.product_id, selectedPhoto);
-                console.log(`상품 ${product.product_id} 기존 피팅 결과 발견:`, result);
+                const result = await fetchProductFittingImage(
+                  product.product_id,
+                  selectedPhoto
+                );
+                console.log(
+                  `상품 ${product.product_id} 기존 피팅 결과 발견:`,
+                  result
+                );
                 return { productId: product.product_id, result };
               } catch (error) {
                 console.log(`상품 ${product.product_id} 기존 피팅 결과 없음`);
@@ -170,53 +185,60 @@ const Home = () => {
               }
             })
           );
-          
+
           // 성공한 결과들만 필터링해서 state에 반영
-          const successfulResults: Record<number, ProductFittingImageResponse> = {};
+          const successfulResults: Record<number, ProductFittingImageResponse> =
+            {};
           existingResults.forEach((promiseResult) => {
-            if (promiseResult.status === 'fulfilled' && promiseResult.value) {
+            if (promiseResult.status === "fulfilled" && promiseResult.value) {
               const { productId, result } = promiseResult.value;
               successfulResults[productId] = result;
             }
           });
-          
+
           console.log("기존 피팅 결과 조회 완료:", successfulResults);
-          
+
           // 조회한 결과를 state에 반영
           if (Object.keys(successfulResults).length > 0) {
             setManualFittingResults(successfulResults);
             console.log("기존 피팅 결과를 state에 반영 완료");
           }
         }
-        
+
         // 최소 3초 대기
         await minLoadingTime;
-        
       } else if (selectedPhoto instanceof File) {
-        // 새로운 파일 업로드인 경우 - 새 피팅 시작 + 폴링
+        // 새로운 파일 업로드인 경우 - 피팅 시작 후 폴링
         console.log("새로운 피팅 시작");
-        
+
         if (products?.products) {
           // 기존 피팅 결과 리셋
           resetFittingResults();
 
-          // useFittingResultsPollingMutation을 사용하여 피팅 시작 + 폴링
+          // 1. 먼저 피팅 시작 (비용 발생, 한 번만)
+          const startResult = await startFittingMutation.mutateAsync(selectedPhoto);
+          console.log("피팅 시작 완료:", startResult);
+
+          // 2. 피팅 결과 폴링 (재시도 안전)
           const fittingResults = await fittingPollingMutation.mutateAsync({
-            imageFile: selectedPhoto,
-            productIds: products.products.map(p => p.product_id),
+            userImageId: startResult.user_image_id,
+            productIds: products.products.map((p) => p.product_id),
             onProgress: (completed, total) => {
               console.log(`피팅 진행률: ${completed}/${total}`);
-            }
+            },
           });
 
           console.log("새 피팅 완료:", fittingResults);
-          
+
           // 상태 업데이트
           setCurrentUserImageId(fittingResults.userImageId);
           setShowFitting(true);
-          
+
           // 새로 생성된 피팅 결과를 state에 반영
-          if (fittingResults.results && Object.keys(fittingResults.results).length > 0) {
+          if (
+            fittingResults.results &&
+            Object.keys(fittingResults.results).length > 0
+          ) {
             setManualFittingResults(fittingResults.results);
             console.log("새 피팅 결과를 state에 반영 완료");
           }
@@ -225,7 +247,6 @@ const Home = () => {
         // 최소 3초 대기 (폴링 내부에서 이미 처리됨)
         await minLoadingTime;
       }
-      
     } catch (error) {
       // 에러가 발생해도 일단 피팅 모드로 전환 (이미 피팅된 결과가 있는 경우 등)
       console.log("피팅 처리 중 에러:", error);
@@ -257,6 +278,7 @@ const Home = () => {
     if (
       (!lastSelectedImage && !lastSelectedUserImageId) ||
       isFittingLoading ||
+      startFittingMutation.isPending ||
       fittingPollingMutation.isPending
     )
       return;
@@ -271,20 +293,21 @@ const Home = () => {
   // 검색어와 카테고리로 상품 필터링
   const filteredProducts = useMemo(() => {
     let sourceProducts: Product[] = [];
-    
+
     if (selectedCategoryId !== null && categoryProducts) {
       // 카테고리 상품의 경우 속성명을 통일 (id -> product_id)
-      sourceProducts = categoryProducts.data?.products?.map((product: any) => ({
-        ...product,
-        product_id: product.id || product.product_id, // id를 product_id로 매핑
-      })) || [];
+      sourceProducts =
+        categoryProducts.data?.products?.map((product: any) => ({
+          ...product,
+          product_id: product.id || product.product_id, // id를 product_id로 매핑
+        })) || [];
     } else {
       sourceProducts = products?.products || [];
     }
 
     const filtered = sourceProducts.filter((product: Product) => {
       if (!product || !product.name || !product.product_id) return false;
-      
+
       const matchesSearch = product.name
         .toLowerCase()
         .includes(searchQuery.toLowerCase());
@@ -298,10 +321,12 @@ const Home = () => {
   // 필터링된 상품을 4개씩 그룹화하여 행으로 나눔
   const productRows = useMemo(() => {
     if (!filteredProducts || filteredProducts.length === 0) return [];
-    
+
     const rows = [];
     for (let i = 0; i < filteredProducts.length; i += 4) {
-      const row = filteredProducts.slice(i, i + 4).filter(product => product && product.product_id);
+      const row = filteredProducts
+        .slice(i, i + 4)
+        .filter((product) => product && product.product_id);
       if (row.length > 0) {
         rows.push(row);
       }
@@ -337,7 +362,7 @@ const Home = () => {
               >
                 {row?.map((product) => {
                   if (!product || !product.product_id) return null;
-                  
+
                   return (
                     <Suspense
                       key={product.product_id}
@@ -353,12 +378,8 @@ const Home = () => {
                         }
                         product={{
                           ...product,
-                          // 피팅 모드일 때 피팅 이미지를 사용, 아니면 원본 이미지 사용
-                          image:
-                            showFitting &&
-                            fittingResults[product.product_id]?.fitting_image
-                              ? fittingResults[product.product_id].fitting_image
-                              : product.image,
+                          // ProductCard에서 애니메이션 처리를 위해 피팅 이미지 정보 전달
+                          fittingImage: fittingResults[product.product_id]?.fitting_image || null,
                         }}
                         onProductClick={() =>
                           handleProductClick(product.product_id)

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -5,6 +5,7 @@ export interface Product {
   price: number;
   image: string;
   content: string;
+  fittingImage?: string | null; // 피팅 이미지 URL (선택적)
 }
 
 // 상품 상세 정보


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---피팅하기 재시도 로직 수정

### ✨ Description

<!-- write down the work details and show the execution results. -->

 - 결과를 폴링하는 커스텀 훅에서 재시도(retry)를 startFittingDetail로 하고 있어서 여러번 중복으로 호출되는 문제가 있었음.
 - 커스텀 훅을 시작, 폴링으로 분리하여 재시도 로직 수정

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #132 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 피팅 과정을 시작하는 단계와 결과를 조회하는 단계를 분리하여 더욱 명확하게 처리할 수 있도록 개선되었습니다.
  * 각 상품별 피팅 이미지가 별도 속성으로 표시되어, 상품 카드에서 피팅 이미지를 명확하게 확인할 수 있습니다.

* **버그 수정**
  * 피팅 이미지 조회 중 오류가 발생한 상품도 완료 처리되어 반복 시도가 발생하지 않도록 수정되었습니다.

* **스타일**
  * 일부 코드 스타일 및 포맷이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->