### PR TITLE
[Feat] 자잘한 디자인 수정 요소들 구현

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -118,21 +118,6 @@ const Footer = ({
                 </div>
               )}
 
-              {/* Gift Option - Cart Only */}
-              {isCart && (
-                <div className="flex items-center gap-[19px]">
-                  <span className="text-black text-[10px] font-inter leading-tight">
-                    선물용으로 주문하시겠습니까?
-                  </span>
-                  <button
-                    onClick={() => {}}
-                    className="text-black text-[10px] font-inter leading-tight hover:opacity-70 transition-opacity cursor-pointer"
-                  >
-                    추가
-                  </button>
-                </div>
-              )}
-
               {/* Bottom Section */}
               <div className="flex justify-between items-center w-[340px] h-[44px]">
                 {/* Total Price */}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -70,7 +70,7 @@ const Header = memo(
     const handleCategoryClick = useCallback(
       (categoryName: string) => {
         let categoryId: number | null = null;
-        
+
         switch (categoryName) {
           case "상의":
             categoryId = 1;
@@ -143,7 +143,7 @@ const Header = memo(
                   // Category Menu (Home 페이지)
                   <div className="flex flex-wrap items-center gap-4 md:gap-6">
                     {categoryItems.map((item, index) => {
-                      const isSelected = 
+                      const isSelected =
                         (item === "모두 보기" && selectedCategoryId === null) ||
                         (item === "상의" && selectedCategoryId === 1) ||
                         (item === "하의" && selectedCategoryId === 2) ||
@@ -205,7 +205,7 @@ const Header = memo(
                         className="text-black hover:opacity-70 transition-opacity bg-transparent border-none outline-none cursor-pointer"
                         aria-label="검색"
                       >
-                        <Search size={25} strokeWidth={1.5} />
+                        <Search size={22} strokeWidth={1.5} />
                       </button>
                     </div>
                   )}
@@ -221,13 +221,13 @@ const Header = memo(
                           onClick={() => navigate("/mypage")}
                           aria-label="마이페이지로 이동"
                         >
-                          <User size={25} strokeWidth={1.5} />
+                          <User size={22} strokeWidth={1.5} />
                         </button>
                       ) : (
                         <Suspense
                           fallback={
                             <div className="text-black w-auto h-4 flex items-center justify-center">
-                              <User size={25} strokeWidth={1.5} />
+                              <User size={22} strokeWidth={1.5} />
                             </div>
                           }
                         >
@@ -237,7 +237,7 @@ const Header = memo(
                               className="text-black w-auto h-4 flex items-center justify-center cursor-pointer hover:opacity-70 transition-opacity bg-transparent border-none outline-none"
                               aria-label="로그인 창 열기"
                             >
-                              <User size={25} strokeWidth={1.5} />
+                              <User size={22} strokeWidth={1.5} />
                             </button>
                           </LoginDialog>
                         </Suspense>
@@ -255,7 +255,7 @@ const Header = memo(
                         aria-label={`장바구니 (상품 ${cartCount}개)`}
                       >
                         <div className="relative">
-                          <ShoppingCart size={25} strokeWidth={1.5} />
+                          <ShoppingCart size={22} strokeWidth={1.5} />
                           {cartCount > 0 && (
                             <span className="absolute -top-1 -right-1 bg-black text-white text-[8px] rounded-full w-4 h-4 flex items-center justify-center font-bold">
                               {cartCount > 99 ? "99+" : cartCount}

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -96,7 +96,7 @@ const Layout = ({ children, totalPrice: propTotalPrice }: LayoutProps) => {
       const scrollY = window.scrollY;
 
       // 애니메이션 구간 정의
-      const videoSectionHeight = 800;
+      const videoSectionHeight = 900;
       const onboardingHeight = 1000;
       const onboardingTopMargin = 100; // pt-[100px]
 

--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -27,13 +27,32 @@ const ProductCard = memo(
       boolean | null
     >(null); // null로 초기화
 
+    // 호버 상태 및 프리패치된 이미지 관리
+    const [isHovering, setIsHovering] = useState(false);
+    const [prefetchedImages, setPrefetchedImages] = useState<string[] | null>(
+      null
+    );
+
     const getTextColor = () => {
       return variant === "viewed" ? "text-[#AAAAAA]" : "text-black";
     };
 
-    const handleMouseEnter = () => {
+    const handleMouseEnter = async () => {
+      setIsHovering(true);
+
       // 호버 시 상품 상세 정보 prefetch
-      prefetchProductDetail(product.product_id);
+      try {
+        const prefetchedData = await prefetchProductDetail(product.product_id);
+        if (prefetchedData?.product_images) {
+          setPrefetchedImages(prefetchedData.product_images);
+        }
+      } catch (error) {
+        console.error("Prefetch failed:", error);
+      }
+    };
+
+    const handleMouseLeave = () => {
+      setIsHovering(false);
     };
 
     // showFitting 상태 변화 감지하여 이전 상태 저장
@@ -92,6 +111,11 @@ const ProductCard = memo(
         return product.image;
       }
 
+      // 호버 상태일 때 프리패치된 이미지의 세 번째 이미지(product_images[2]) 표시
+      if (isHovering && prefetchedImages && prefetchedImages[2]) {
+        return prefetchedImages[2];
+      }
+
       // 애니메이션 중이 아니면 현재 상태에 맞는 이미지 표시
       if (!isAnimating) {
         return showFitting && product.fittingImage
@@ -121,6 +145,7 @@ const ProductCard = memo(
       <div
         className="w-full max-w-[240px] min-w-[180px] sm:w-[240px]"
         onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         {/* Product Image */}
         <div
@@ -144,7 +169,7 @@ const ProductCard = memo(
             key={`product-${product.product_id}`}
             src={foregroundImageUrl}
             alt={showFitting ? `${product.name} - 피팅 결과` : product.name}
-            className="w-full h-full object-contain absolute inset-0 hover:scale-105 transition-transform duration-300"
+            className="w-full h-full object-contain absolute inset-0 transition-transform duration-300"
             style={{
               imageRendering: "auto",
             }}

--- a/src/components/dialogs/CartAddDialog.tsx
+++ b/src/components/dialogs/CartAddDialog.tsx
@@ -58,13 +58,13 @@ const CartAddDialog = ({ isOpen, onClose, product }: CartAddDialogProps) => {
             </div>
 
             {/* Product Info */}
-            <div className="h-full flex items-start pt-[76px]">
-              <div className="flex flex-col gap-[7px]">
-                <p className="text-black text-[14px] font-inter font-bold leading-[18px] tracking-[-0.013em]">
+            <div className="h-full flex items-start pt-[76px] w-[300px]">
+              <div className="flex flex-col gap-[7px] w-full">
+                <p className="text-black text-[14px] font-inter font-bold leading-[18px] tracking-[-0.013em] break-words">
                   {product.name}
                 </p>
-                <p className="text-black text-[12px] font-inter font-medium leading-[18px] tracking-[-0.013em]">
-                  {product.content}
+                <p className="text-black text-[12px] font-inter font-medium leading-[18px] tracking-[-0.013em] break-words">
+                  {product.content.split("/")[0]}
                 </p>
                 <p className="text-black text-[12px] font-inter font-medium leading-[18px] tracking-[-0.013em]">
                   {product.price}원

--- a/src/components/modals/PhotoSelectionModal.tsx
+++ b/src/components/modals/PhotoSelectionModal.tsx
@@ -54,7 +54,7 @@ export default function PhotoSelectionModal({
         <DialogTitle>전신사진 선택</DialogTitle>
       </DialogHeader>
 
-      <div className="space-y-6">
+      <div className="space-y-6 max-w-[550px]">
         {/* 파일 업로드 섹션 */}
         <div>
           <h3 className="text-lg font-medium text-gray-900 mb-4">
@@ -102,7 +102,7 @@ export default function PhotoSelectionModal({
                   <button
                     onClick={(e) => handleDeleteImage(e, image.id)}
                     disabled={isDeleting}
-                    className="absolute top-2 right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 transition-colors disabled:opacity-50 disabled:cursor-not-allowed z-10"
+                    className="absolute top-2 right-2 bg-gray-300 hover:bg-gray-400 text-white rounded-full p-1 transition-colors disabled:opacity-50 disabled:cursor-not-allowed z-10"
                     title="사진 삭제"
                   >
                     <X size={16} />

--- a/src/components/sections/MorphLogo.tsx
+++ b/src/components/sections/MorphLogo.tsx
@@ -6,9 +6,9 @@ const MorphLogo = () => {
     "fixed" | "absolute" | "scaling"
   >("fixed");
 
-  const absoluteStartPoint = 800; // absolute 구간 시작 지점
-  const scalingStartPoint = 1000; // 축소 시작 지점 (200px 구간 후)
-  const scalingEndPoint = 2000; // 축소 완료 지점
+  const absoluteStartPoint = 850; // absolute 구간 시작 지점 (비디오 높이 증가에 맞춰 조정)
+  const scalingStartPoint = 1050; // 축소 시작 지점 (200px 구간 후)
+  const scalingEndPoint = 2050; // 축소 완료 지점
   const rafRef = useRef<number>(0);
 
   // Easing 함수 - ease-out 곡선 (부드러운 감속)
@@ -62,7 +62,7 @@ const MorphLogo = () => {
   const getLogoStyles = () => {
     const baseSize = 200;
     const headerSize = 60;
-    const baseTop = 300;
+    const baseTop = 350;
     const headerTop = 40;
 
     switch (positionState) {

--- a/src/components/sections/ProfileSection.tsx
+++ b/src/components/sections/ProfileSection.tsx
@@ -4,9 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useModal } from "@/contexts/ModalContext";
 import { useOrder } from "@/contexts/OrderContext";
 import { formatPhoneNumber } from "@/lib/utils";
-import ProfileImage from "@/components/common/ProfileImage";
 import VirtualFittingVideos from "@/components/sections/VirtualFittingVideos";
-
 
 interface ProfileSectionProps {
   onEditSection?: (section: string) => void;
@@ -31,14 +29,15 @@ interface Address {
 }
 
 const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
-  const [profileImage, setProfileImage] = useState<string | null>(null);
   const [personalInfo, setPersonalInfo] = useState<PersonalInfo | null>(null);
   const [addresses, setAddresses] = useState<Address[]>([]);
   const { openModal } = useModal();
   const { currentBuyerInfo } = useOrder();
 
   // BuyerInfo를 Address 형식으로 변환하는 함수
-  const convertBuyerInfoToAddress = (buyerInfo: typeof currentBuyerInfo): Address => {
+  const convertBuyerInfoToAddress = (
+    buyerInfo: typeof currentBuyerInfo
+  ): Address => {
     return {
       id: "temp_buyer_address", // 임시 ID
       name: "기본 주소 (주문 정보에서)",
@@ -60,22 +59,22 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
         email: personalInfo?.email || "",
         phone: personalInfo?.phone || currentBuyerInfo?.phone || "",
       };
-      
+
       // PersonalInfoForm에서 제출했을 때 personalInfo 상태 업데이트
       const handlePersonalInfoSubmit = (data: PersonalInfo) => {
         setPersonalInfo(data);
       };
-      
+
       openModal("personalInfo", currentData, handlePersonalInfoSubmit);
     } else if (section === "addresses") {
       // AddressManagement에서 주소 변경 시 호출될 콜백
       const handleAddressSubmit = (updatedAddresses: Address[]) => {
         setAddresses(updatedAddresses);
       };
-      
+
       // 초기 주소 데이터 준비
       let initialAddressData: Address[] = [];
-      
+
       // 1. 사용자가 저장한 주소가 있으면 그것을 사용
       if (addresses.length > 0) {
         initialAddressData = addresses;
@@ -84,16 +83,16 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
       else if (currentBuyerInfo) {
         initialAddressData = [convertBuyerInfoToAddress(currentBuyerInfo)];
       }
-      
-      openModal("addresses", undefined, undefined, handleAddressSubmit, initialAddressData);
+
+      openModal(
+        "addresses",
+        undefined,
+        undefined,
+        handleAddressSubmit,
+        initialAddressData
+      );
     }
     onEditSection?.(section);
-  };
-
-  const handleProfileImageChange = (imageUrl: string | null) => {
-    setProfileImage(imageUrl);
-    // 실제로는 auth context나 API를 통해 서버에 저장
-    console.log("프로필 이미지 업데이트:", imageUrl);
   };
 
   return (
@@ -101,16 +100,6 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
       <h2 className="text-xl font-semibold mb-6">프로필 정보</h2>
       {/* 프로필 섹션 */}
       <div className="flex gap-4">
-        {/* 프로필 이미지 섹션 */}
-        <div className="flex justify-center items-center mb-6 w-[400px]">
-          <ProfileImage
-            currentImage={profileImage || undefined}
-            userName={personalInfo?.name || currentBuyerInfo?.name || "사용자"}
-            onImageChange={handleProfileImageChange}
-            size="lg"
-          />
-        </div>
-
         <Card className="mb-10 w-full">
           <CardHeader>
             <CardTitle className="text-lg">개인정보</CardTitle>
@@ -125,15 +114,23 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">사용자명</span>
-                <span className="text-gray-900">{personalInfo?.username || "-"}</span>
+                <span className="text-gray-900">
+                  {personalInfo?.username || "-"}
+                </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">이메일</span>
-                <span className="text-gray-900">{personalInfo?.email || "-"}</span>
+                <span className="text-gray-900">
+                  {personalInfo?.email || "-"}
+                </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-gray-500 text-sm">전화번호</span>
-                <span className="text-gray-900">{formatPhoneNumber(personalInfo?.phone || currentBuyerInfo?.phone || "")}</span>
+                <span className="text-gray-900">
+                  {formatPhoneNumber(
+                    personalInfo?.phone || currentBuyerInfo?.phone || ""
+                  )}
+                </span>
               </div>
             </div>
             <div className="mt-4 pt-4 border-t">
@@ -197,13 +194,17 @@ const ProfileSection = memo(({ onEditSection }: ProfileSectionProps) => {
                       임시 배송지
                     </span>
                   </div>
-                  <p className="text-sm text-gray-600">{currentBuyerInfo.name}</p>
+                  <p className="text-sm text-gray-600">
+                    {currentBuyerInfo.name}
+                  </p>
                   <p className="text-sm text-gray-500">
                     {currentBuyerInfo.address}
-                    {currentBuyerInfo.address2 && `, ${currentBuyerInfo.address2}`}
+                    {currentBuyerInfo.address2 &&
+                      `, ${currentBuyerInfo.address2}`}
                   </p>
                   <p className="text-xs text-gray-400">
-                    {currentBuyerInfo.postalCode} | {formatPhoneNumber(currentBuyerInfo.phone)}
+                    {currentBuyerInfo.postalCode} |{" "}
+                    {formatPhoneNumber(currentBuyerInfo.phone)}
                   </p>
                   <p className="text-xs text-gray-400">
                     {currentBuyerInfo.region} ({currentBuyerInfo.regionCode})

--- a/src/components/sections/VideoSection.tsx
+++ b/src/components/sections/VideoSection.tsx
@@ -59,7 +59,7 @@ const VideoSection = memo(() => {
         ref={videoRef}
         autoPlay
         muted
-        className={`w-full h-[800px] object-cover object-top transition-opacity duration-300 ${
+        className={`w-full h-[900px] object-cover object-top transition-opacity duration-300 ${
           isLoaded ? "opacity-100" : "opacity-0"
         }`}
         onEnded={handleVideoEnded}

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -36,8 +36,8 @@ type Address = {
 
 type ModalContextType = {
   openModal: (
-    type: ModalType, 
-    initialData?: PersonalInfoData, 
+    type: ModalType,
+    initialData?: PersonalInfoData,
     onSubmitCallback?: (data: PersonalInfoData) => void,
     onAddressCallback?: (addresses: Address[]) => void,
     initialAddresses?: Address[],
@@ -52,14 +52,20 @@ const ModalContext = createContext<ModalContextType | undefined>(undefined);
 export const ModalProvider = ({ children }: { children: ReactNode }) => {
   const [modalType, setModalType] = useState<ModalType>(null);
   const [initialData, setInitialData] = useState<PersonalInfoData | null>(null);
-  const [submitCallback, setSubmitCallback] = useState<((data: PersonalInfoData) => void) | null>(null);
-  const [addressCallback, setAddressCallback] = useState<((addresses: Address[]) => void) | null>(null);
+  const [submitCallback, setSubmitCallback] = useState<
+    ((data: PersonalInfoData) => void) | null
+  >(null);
+  const [addressCallback, setAddressCallback] = useState<
+    ((addresses: Address[]) => void) | null
+  >(null);
   const [initialAddresses, setInitialAddresses] = useState<Address[]>([]);
-  const [photoSelectionCallback, setPhotoSelectionCallback] = useState<((selectedPhoto: File | string | number) => void) | null>(null);
+  const [photoSelectionCallback, setPhotoSelectionCallback] = useState<
+    ((selectedPhoto: File | string | number) => void) | null
+  >(null);
 
   const openModal = (
-    type: ModalType, 
-    data?: PersonalInfoData, 
+    type: ModalType,
+    data?: PersonalInfoData,
     onSubmitCallback?: (data: PersonalInfoData) => void,
     onAddressCallback?: (addresses: Address[]) => void,
     initialAddressData?: Address[],
@@ -100,7 +106,7 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
           if (!open) closeModal();
         }}
       >
-        <DialogContent className="sm:max-w-[600px] max-h-[80vh] overflow-y-auto">
+        <DialogContent className="sm:max-w-[600px] overflow-y-auto">
           <VisuallyHidden>
             <DialogTitle>Modal</DialogTitle>
           </VisuallyHidden>
@@ -119,26 +125,26 @@ export const ModalProvider = ({ children }: { children: ReactNode }) => {
                 onClose={closeModal}
                 onSubmit={async (data) => {
                   console.log("개인정보 업데이트:", data);
-                  
+
                   // ProfileSection의 setPersonalInfo 콜백 호출
                   if (submitCallback) {
                     submitCallback(data);
                   }
-                  
+
                   // Mock delay
                   await new Promise((resolve) => setTimeout(resolve, 1000));
                 }}
               />
             )}
             {modalType === "addresses" && (
-              <AddressManagement 
+              <AddressManagement
                 onClose={closeModal}
                 onAddressUpdate={addressCallback}
                 initialAddresses={initialAddresses}
               />
             )}
             {modalType === "photoSelection" && (
-              <PhotoSelectionModal 
+              <PhotoSelectionModal
                 onClose={closeModal}
                 onPhotoSelect={photoSelectionCallback}
               />

--- a/src/hooks/useHeaderSticky.ts
+++ b/src/hooks/useHeaderSticky.ts
@@ -11,7 +11,7 @@ export const useHeaderSticky = () => {
       const isHomePage = location.pathname === "/";
 
       if (isHomePage) {
-        const videoSectionHeight = 800;
+        const videoSectionHeight = 900;
         const onBoardingHeight = 1000;
         const stickyThreshold = videoSectionHeight + onBoardingHeight;
         setIsSticky(currentScrollY >= stickyThreshold);

--- a/src/hooks/usePrefetch.ts
+++ b/src/hooks/usePrefetch.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchProducts, fetchProductDetail } from "../api/products";
+import type { ProductDetail } from "../types/product";
 
 /**
  * 상품 데이터 prefetching을 위한 커스텀 훅
@@ -17,12 +18,19 @@ export const usePrefetch = () => {
   };
 
   // 상품 상세 prefetch (호버 시 미리 로드)
-  const prefetchProductDetail = async (productId: number) => {
+  const prefetchProductDetail = async (productId: number): Promise<ProductDetail | undefined> => {
+    const cachedData = queryClient.getQueryData<ProductDetail>(["product", productId]);
+    if (cachedData) {
+      return cachedData;
+    }
+
     await queryClient.prefetchQuery({
       queryKey: ["product", productId],
       queryFn: () => fetchProductDetail(productId),
       staleTime: 5 * 60 * 1000,
     });
+
+    return queryClient.getQueryData<ProductDetail>(["product", productId]);
   };
 
   return {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,7 +36,6 @@ const Home = () => {
     setCurrentUserImageId,
     hasLastSelectedImage,
   } = useFittingContext();
-  const [buttonText, setButtonText] = useState<string>("피팅하기");
   const [viewedProducts, setViewedProducts] = useState<string[]>([]);
   const [categoryProducts, setCategoryProducts] =
     useState<CategoryResponse | null>(null);
@@ -70,7 +69,6 @@ const Home = () => {
 
   // 홈 페이지로 돌아올 때마다 피팅 모드 해제 (피팅 결과 ID는 보존)
   useEffect(() => {
-    setShowFitting(false);
     // setCurrentUserImageId(null); // ← 제거: 최근 피팅 결과 보존
     resetFittingResults();
   }, []); // 컴포넌트 마운트 시에만 실행
@@ -145,12 +143,9 @@ const Home = () => {
     }
 
     setIsFittingLoading(true);
-    setButtonText("피팅 중...");
 
     // 2초 후 완료 텍스트로 변경
-    setTimeout(() => {
-      setButtonText("완료!");
-    }, 2000);
+    setTimeout(() => {}, 2000);
 
     // 최소 3초 로딩 보장을 위한 타이머 시작
     const minLoadingTime = new Promise((resolve) => setTimeout(resolve, 3000));
@@ -275,7 +270,6 @@ const Home = () => {
     } finally {
       // 로딩 상태 해제
       setIsFittingLoading(false);
-      setButtonText(showFitting ? "피팅 다시하기" : "피팅하기");
     }
   };
 
@@ -420,7 +414,7 @@ const Home = () => {
         )}
 
         {/* 바로 피팅하기 버튼 (이전 선택 이미지가 있는 경우) */}
-        {hasLastSelectedImage && !isFittingLoading && (
+        {!showFitting && hasLastSelectedImage && !isFittingLoading && (
           <button
             className="w-[240px] bg-white border border-black border-solid border-2 text-black px-4 py-2 rounded-lg shadow-lg hover:bg-gray-100 transition-colors font-inter text-sm"
             onClick={handleQuickFitting}
@@ -439,20 +433,7 @@ const Home = () => {
           onClick={handleFittingClick}
           disabled={isFittingLoading}
         >
-          {/* 진행 배경 애니메이션
-          {isFittingLoading && (
-            <div
-              className="absolute inset-0 bg-green-400"
-              style={{
-                animation: "slideRight 3s linear forwards",
-              }}
-            />
-          )} */}
-
-          {/* 버튼 텍스트 */}
-          <span className="relative z-10 font-medium">
-            {isFittingLoading ? buttonText : "피팅하기"}
-          </span>
+          <span className="relative z-10 font-medium">사진 선택하기</span>
         </button>
       </div>
     </div>

--- a/src/pages/OrderHistory.tsx
+++ b/src/pages/OrderHistory.tsx
@@ -55,15 +55,15 @@ function OrderHistory() {
       {/* Main Content */}
       <div className="pt-[149px] px-4 pb-8">
         {/* Page Title */}
-        <div className="ml-[114px] mb-9">
+        <div className="mx-[114px] mb-9">
           <h1 className="text-black text-[20px] font-bold font-inter leading-[30px]">
-            결재 내역
+            결제 내역
           </h1>
           <div className="w-[77px] h-[1px] bg-black mt-1"></div>
         </div>
 
         {/* Order Content */}
-        <div className="ml-[109px] flex items-start gap-[66px]">
+        <div className="mx-[109px] flex items-start gap-[100px]">
           {/* Product Image */}
           <div className="w-[118px] h-[178px] bg-white rounded overflow-hidden">
             {firstProduct && (
@@ -76,13 +76,13 @@ function OrderHistory() {
           </div>
 
           {/* Order Details */}
-          <div className="w-[946px] flex flex-col gap-[59px]">
+          <div className="w-full flex flex-col gap-[59px]">
             {/* Header Row */}
             <div className="flex items-center">
-              <span className="text-black text-[20px] font-medium font-inter leading-[30px] w-[240px]">
+              <span className="text-black text-[20px] font-medium font-inter leading-[30px] w-[340px]">
                 날짜
               </span>
-              <span className="text-black text-[20px] font-medium font-inter leading-[30px] w-[400px]">
+              <span className="text-black text-[20px] font-medium font-inter leading-[30px] w-[500px]">
                 상품명
               </span>
               <span className="text-black text-[20px] font-medium font-inter leading-[30px] w-[100px]">
@@ -92,10 +92,10 @@ function OrderHistory() {
 
             {/* Data Row */}
             <div className="flex items-center">
-              <span className="text-black text-[17px] font-normal font-inter leading-[25px] w-[240px]">
+              <span className="text-black text-[17px] font-normal font-inter leading-[25px] w-[340px]">
                 {formatDate(latestOrder.orderDate)}
               </span>
-              <span className="text-black text-[17px] font-normal font-inter leading-[25px] w-[400px]">
+              <span className="text-black text-[17px] font-normal font-inter leading-[25px] w-[500px]">
                 {firstProduct?.name}
                 {latestOrder.products.length > 1 &&
                   ` 외 ${latestOrder.products.length - 1}개`}
@@ -139,7 +139,7 @@ function OrderHistory() {
         </div>
 
         {/* Bottom Line */}
-        <div className="ml-[105px] mt-[38px] w-[1198px] h-[1px] bg-[#C1BCBC]"></div>
+        <div className="mx-[105px] mt-[38px] w-[1275px] h-[1px] bg-[#C1BCBC]"></div>
 
         {/* Continue Shopping Button */}
         <div className="flex justify-end mr-[137px] mt-[115px]">

--- a/src/pages/OrderSummary.tsx
+++ b/src/pages/OrderSummary.tsx
@@ -94,7 +94,7 @@ function OrderSummary() {
           </div>
         </div>
 
-        <div className="w-[493px] space-y-[109px]">
+        <div className="w-full space-y-[109px]">
           <div className="flex flex-col gap-28">
             {/* 배송 정보 */}
             <div className="space-y-3">
@@ -142,7 +142,7 @@ function OrderSummary() {
             </div>
 
             {/* 결제 정보 */}
-            <div className="w-[290px] space-y-3">
+            <div className="w-full space-y-3">
               <h2 className="text-[17px] font-bold text-black">결제 정보</h2>
               <div className="space-y-3">
                 <p className="text-[17px] font-medium text-black">크레딧</p>


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---자잘한 디자인 수정 요소들 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

  사진 변경 애니메이션 및 UI 개선

  - 피팅하기 버튼 텍스트 개선: "피팅하기" → "사진 선택하기"로 변경하여 사용자 경험 향상
  - 호버 효과 구현: 상품 카드 마우스 호버 시 product_images[2] 이미지를 프리패치하여 표시
  - 스크롤 반응형 헤더: 스크롤에 따른 헤더 움직임 및 아이콘 크기 조정으로 UX 개선
  - 비디오 섹션 확장: 비디오 섹션 높이 100px 증가, 로고 애니메이션 위치 조정
  - 모달창 UX 개선: 피팅하기 모달창 높이 제한 제거, 너비 제한 및 삭제 버튼 개선
  - 텍스트 오버플로우 수정: 상품 설명 및 장바구니 모달 내용에서 텍스트 넘침 문제 해결
  - 크레딧 시스템 연동: 주문 생성 시 크레딧 연동 및 에러 메시지 알림 기능 구현
  - 타입 안전성 강화: TypeScript 타입 오류 수정 및 프리패치 기능 타입 정의 개선

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 상품 카드에서 마우스 오버 시 상품 상세 이미지를 비동기적으로 미리 불러오고, 세 번째 이미지를 표시하도록 개선되었습니다.

* **버그 수정**
  * 결제 내역 페이지의 한글 오타(“결재 내역” → “결제 내역”)가 수정되었습니다.

* **스타일**
  * 헤더의 검색, 사용자, 장바구니 아이콘 크기가 25에서 22로 축소되었습니다.
  * 주문 내역, 주문 요약, 장바구니 추가 다이얼로그, 사진 선택 모달 등 여러 UI의 레이아웃 및 마진, 폭, 버튼 색상이 개선되어 가독성과 일관성이 향상되었습니다.

* **기능 제거**
  * 푸터(장바구니 변형)의 “선물 옵션” UI가 삭제되었습니다.
  * 프로필 섹션에서 프로필 이미지 업로드 및 표시 기능이 제거되었습니다.

* **기타**
  * 홈 fitting 버튼의 동적 텍스트 및 애니메이션이 제거되어 항상 “사진 선택하기”로 고정됩니다.
  * 여러 스크롤 기반 애니메이션(온보딩, 로고, 헤더 스티키 등)의 시작/종료 지점 및 컨테이너 높이가 800px → 900px(또는 +50px)로 조정되었습니다.
  * 코드 내 불필요한 공백 및 포맷이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->